### PR TITLE
Add missing cygwin headers

### DIFF
--- a/src/system.c
+++ b/src/system.c
@@ -43,6 +43,11 @@
 #include        <readline/readline.h>   /* readline for interactive input  */
 #endif
 
+#if HAVE_SYS_TIMES_H                    /* time functions                  */
+# include       <sys/types.h>
+# include       <sys/times.h>
+#endif
+
 #if HAVE_MADVISE
 #include        <sys/mman.h>
 #endif


### PR DESCRIPTION
This patch ensures that cygwin GAP build, and produces a working basic GAP (without DLL support, which is needed to load kernel packages)
