### PR TITLE
Add more variants for Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,11 +7,26 @@ env:
   global:
     - CFLAGS="-fprofile-arcs -ftest-coverage"
     - LDFLAGS="-fprofile-arcs"
+    - BUILDDIR=.
+  matrix:
+  # - TEST_SUITE=testinstall ABI=32 # trusty is missing 32bit gmp, see https://github.com/travis-ci/apt-package-whitelist/pull/4018
+    - TEST_SUITE=testinstall ABI=32 CONFIGFLAGS=--with-gmp=builtin
+    - TEST_SUITE=testinstall ABI=64
+    - TEST_SUITE=testinstall ABI=64 CONFIGFLAGS=--with-gmp=builtin
+      # out of three builds
+    - TEST_SUITE=testinstall ABI=32 BUILDDIR=build CONFIGFLAGS=--with-gmp=builtin
+    - TEST_SUITE=testinstall ABI=64 BUILDDIR=build
+    - TEST_SUITE=testinstall ABI=64 BUILDDIR=build CONFIGFLAGS=--with-gmp=builtin
+
+# TODO: boehm GC, HPC-GAP compatibility mode
 
 addons:
   apt_packages:
     - libgmp-dev
     - libreadline-dev
+    - gcc-multilib
+    - g++-multilib
+    - texinfo
 
 matrix:
   include:
@@ -77,11 +92,15 @@ after_success:
   - bash <(curl -s https://codecov.io/bash)
 
 script:
+  - export GAPROOT=$TRAVIS_BUILD_DIR
   - ./autogen.sh
-  - ./configure
+  - mkdir -p $BUILDDIR
+  - cd $BUILDDIR
+  - $GAPROOT/configure $CONFIGFLAGS
   - make -j4
   - make bootstrap-pkg-full
-  - bash etc/ci.sh
+  - if [[ $BUILDDIR != . ]] ; then mv pkg $GAPROOT/ ; fi
+  - bash $GAPROOT/etc/ci.sh
 
 notifications:
   slack:

--- a/etc/ci.sh
+++ b/etc/ci.sh
@@ -8,11 +8,14 @@
 
 set -ex
 
+GAPROOT=${GAPROOT:-$PWD}
+BUILDDIR=${BUILDDIR:-.}
+
 if [[ "${TEST_SUITE}" == makemanuals ]]
 then
     make manuals
-    cat doc/*/make_manuals.out
-    if [[ $(cat doc/*/make_manuals.out | grep -c "manual.lab written") != '3' ]]
+    cat  $GAPROOT/doc/*/make_manuals.out
+    if [[ $(cat  $GAPROOT/doc/*/make_manuals.out | grep -c "manual.lab written") != '3' ]]
     then
         echo "Build failed"
         exit 1
@@ -27,10 +30,10 @@ fi
 
 # We need to compile the profiling package in order to generate coverage
 # reports; and also the IO package, as the profiling package depends on it.
-pushd pkg
+pushd $GAPROOT/pkg
 
 cd io*
-./configure $CONFIGFLAGS
+./configure $CONFIGFLAGS --with-gaproot=$GAPROOT/$BUILDDIR
 make
 cd ..
 
@@ -40,7 +43,7 @@ rm -rf profiling*
 git clone https://github.com/gap-packages/profiling
 cd profiling
 ./autogen.sh
-./configure $CONFIGFLAGS
+./configure $CONFIGFLAGS --with-gaproot=$GAPROOT/$BUILDDIR
 make
 
 # return to base directory
@@ -53,15 +56,15 @@ mkdir -p $COVDIR
 
 case ${TEST_SUITE} in
 testmanuals)
-    bin/gap.sh -q tst/extractmanuals.g
+    bin/gap.sh -q $GAPROOT/tst/extractmanuals.g
 
     bin/gap.sh -q <<GAPInput
-        Read("tst/testmanuals.g");
+        Read("$GAPROOT/tst/testmanuals.g");
         SaveWorkspace("testmanuals.wsp");
         QUIT_GAP(0);
 GAPInput
 
-    for ch in tst/testmanuals/*.tst
+    for ch in $GAPROOT/tst/testmanuals/*.tst
     do
         bin/gap.sh -q -L testmanuals.wsp --cover $COVDIR/$(basename $ch).coverage <<GAPInput
         TestManualChapter("$ch");
@@ -77,20 +80,20 @@ GAPInput
 
     # run gap compiler to verify the src/c_*.c files are up-todate,
     # and also get coverage on the compiler
-    etc/docomp
+    make docomp
 
     # detect if there are any diffs
     git diff --exit-code
 
     ;;
 *)
-    if [[ ! -f  tst/${TEST_SUITE}.g ]]
+    if [[ ! -f  $GAPROOT/tst/${TEST_SUITE}.g ]]
     then
-        echo "Could not read test suite tst/${TEST_SUITE}.g"
+        echo "Could not read test suite $GAPROOT/tst/${TEST_SUITE}.g"
         exit 1
     fi
 
-    bin/gap.sh --cover $COVDIR/${TEST_SUITE}.coverage tst/${TEST_SUITE}.g
+    bin/gap.sh --cover $COVDIR/${TEST_SUITE}.coverage $GAPROOT/tst/${TEST_SUITE}.g
 esac;
 
 # generate library coverage reports

--- a/src/c_filter1.c
+++ b/src/c_filter1.c
@@ -125,7 +125,7 @@ static Obj  HdlrFunc3 (
  /* hash := HASH_FLAGS( flags ) mod 11001; */
  t_3 = GF_HASH__FLAGS;
  t_2 = CALL_1ARGS( t_3, a_flags );
- CHECK_FUNC_RESULT( t_2 );
+ CHECK_FUNC_RESULT( t_2 )
  t_1 = MOD( t_2, INTOBJ_INT(11001) );
  l_hash = t_1;
  
@@ -136,17 +136,17 @@ static Obj  HdlrFunc3 (
   l_i = t_1;
   
   /* hash2 := 2 * ((hash + 31 * i) mod 11001) + 1; */
-  C_PROD_INTOBJS( t_6, INTOBJ_INT(31), l_i );
-  C_SUM_FIA( t_5, l_hash, t_6 );
+  C_PROD_INTOBJS( t_6, INTOBJ_INT(31), l_i )
+  C_SUM_FIA( t_5, l_hash, t_6 )
   t_4 = MOD( t_5, INTOBJ_INT(11001) );
-  C_PROD_FIA( t_3, INTOBJ_INT(2), t_4 );
-  C_SUM_FIA( t_2, t_3, INTOBJ_INT(1) );
+  C_PROD_FIA( t_3, INTOBJ_INT(2), t_4 )
+  C_SUM_FIA( t_2, t_3, INTOBJ_INT(1) )
   l_hash2 = t_2;
   
   /* if IsBound( WITH_IMPS_FLAGS_CACHE[hash2] ) then */
   t_4 = GC_WITH__IMPS__FLAGS__CACHE;
-  CHECK_BOUND( t_4, "WITH_IMPS_FLAGS_CACHE" );
-  CHECK_INT_POS( l_hash2 );
+  CHECK_BOUND( t_4, "WITH_IMPS_FLAGS_CACHE" )
+  CHECK_INT_POS( l_hash2 )
   t_3 = C_ISB_LIST( t_4, l_hash2 );
   t_2 = (Obj)(UInt)(t_3 != False);
   if ( t_2 ) {
@@ -154,26 +154,26 @@ static Obj  HdlrFunc3 (
    /* if IS_IDENTICAL_OBJ( WITH_IMPS_FLAGS_CACHE[hash2], flags ) then */
    t_4 = GF_IS__IDENTICAL__OBJ;
    t_6 = GC_WITH__IMPS__FLAGS__CACHE;
-   CHECK_BOUND( t_6, "WITH_IMPS_FLAGS_CACHE" );
-   C_ELM_LIST_FPL( t_5, t_6, l_hash2 );
+   CHECK_BOUND( t_6, "WITH_IMPS_FLAGS_CACHE" )
+   C_ELM_LIST_FPL( t_5, t_6, l_hash2 )
    t_3 = CALL_2ARGS( t_4, t_5, a_flags );
-   CHECK_FUNC_RESULT( t_3 );
-   CHECK_BOOL( t_3 );
+   CHECK_FUNC_RESULT( t_3 )
+   CHECK_BOOL( t_3 )
    t_2 = (Obj)(UInt)(t_3 != False);
    if ( t_2 ) {
     
     /* WITH_IMPS_FLAGS_CACHE_HIT := WITH_IMPS_FLAGS_CACHE_HIT + 1; */
     t_3 = GC_WITH__IMPS__FLAGS__CACHE__HIT;
-    CHECK_BOUND( t_3, "WITH_IMPS_FLAGS_CACHE_HIT" );
-    C_SUM_FIA( t_2, t_3, INTOBJ_INT(1) );
+    CHECK_BOUND( t_3, "WITH_IMPS_FLAGS_CACHE_HIT" )
+    C_SUM_FIA( t_2, t_3, INTOBJ_INT(1) )
     AssGVar( G_WITH__IMPS__FLAGS__CACHE__HIT, t_2 );
     
     /* return WITH_IMPS_FLAGS_CACHE[hash2 + 1]; */
     t_3 = GC_WITH__IMPS__FLAGS__CACHE;
-    CHECK_BOUND( t_3, "WITH_IMPS_FLAGS_CACHE" );
-    C_SUM_FIA( t_4, l_hash2, INTOBJ_INT(1) );
-    CHECK_INT_POS( t_4 );
-    C_ELM_LIST_FPL( t_2, t_3, t_4 );
+    CHECK_BOUND( t_3, "WITH_IMPS_FLAGS_CACHE" )
+    C_SUM_FIA( t_4, l_hash2, INTOBJ_INT(1) )
+    CHECK_INT_POS( t_4 )
+    C_ELM_LIST_FPL( t_2, t_3, t_4 )
     RES_BRK_CURR_STAT();
     SWITCH_TO_OLD_FRAME(oldFrame);
     return t_2;
@@ -201,22 +201,22 @@ static Obj  HdlrFunc3 (
   
   /* WITH_IMPS_FLAGS_COUNT := (WITH_IMPS_FLAGS_COUNT + 1) mod 4; */
   t_3 = GC_WITH__IMPS__FLAGS__COUNT;
-  CHECK_BOUND( t_3, "WITH_IMPS_FLAGS_COUNT" );
-  C_SUM_FIA( t_2, t_3, INTOBJ_INT(1) );
+  CHECK_BOUND( t_3, "WITH_IMPS_FLAGS_COUNT" )
+  C_SUM_FIA( t_2, t_3, INTOBJ_INT(1) )
   t_1 = MOD( t_2, INTOBJ_INT(4) );
   AssGVar( G_WITH__IMPS__FLAGS__COUNT, t_1 );
   
   /* i := WITH_IMPS_FLAGS_COUNT; */
   t_1 = GC_WITH__IMPS__FLAGS__COUNT;
-  CHECK_BOUND( t_1, "WITH_IMPS_FLAGS_COUNT" );
+  CHECK_BOUND( t_1, "WITH_IMPS_FLAGS_COUNT" )
   l_i = t_1;
   
   /* hash2 := 2 * ((hash + 31 * i) mod 11001) + 1; */
-  C_PROD_FIA( t_5, INTOBJ_INT(31), l_i );
-  C_SUM_FIA( t_4, l_hash, t_5 );
+  C_PROD_FIA( t_5, INTOBJ_INT(31), l_i )
+  C_SUM_FIA( t_4, l_hash, t_5 )
   t_3 = MOD( t_4, INTOBJ_INT(11001) );
-  C_PROD_FIA( t_2, INTOBJ_INT(2), t_3 );
-  C_SUM_FIA( t_1, t_2, INTOBJ_INT(1) );
+  C_PROD_FIA( t_2, INTOBJ_INT(2), t_3 )
+  C_SUM_FIA( t_1, t_2, INTOBJ_INT(1) )
   l_hash2 = t_1;
   
  }
@@ -224,8 +224,8 @@ static Obj  HdlrFunc3 (
  
  /* WITH_IMPS_FLAGS_CACHE_MISS := WITH_IMPS_FLAGS_CACHE_MISS + 1; */
  t_2 = GC_WITH__IMPS__FLAGS__CACHE__MISS;
- CHECK_BOUND( t_2, "WITH_IMPS_FLAGS_CACHE_MISS" );
- C_SUM_FIA( t_1, t_2, INTOBJ_INT(1) );
+ CHECK_BOUND( t_2, "WITH_IMPS_FLAGS_CACHE_MISS" )
+ C_SUM_FIA( t_1, t_2, INTOBJ_INT(1) )
  AssGVar( G_WITH__IMPS__FLAGS__CACHE__MISS, t_1 );
  
  /* with := flags; */
@@ -246,7 +246,7 @@ static Obj  HdlrFunc3 (
   
   /* for imp in IMPLICATIONS do */
   t_4 = GC_IMPLICATIONS;
-  CHECK_BOUND( t_4, "IMPLICATIONS" );
+  CHECK_BOUND( t_4, "IMPLICATIONS" )
   if ( IS_SMALL_LIST(t_4) ) {
    t_3 = (Obj)(UInt)1;
    t_1 = INTOBJ_INT(1);
@@ -270,18 +270,18 @@ static Obj  HdlrFunc3 (
    
    /* if IS_SUBSET_FLAGS( with, imp[2] ) and not IS_SUBSET_FLAGS( with, imp[1] ) then */
    t_8 = GF_IS__SUBSET__FLAGS;
-   C_ELM_LIST_FPL( t_9, l_imp, INTOBJ_INT(2) );
+   C_ELM_LIST_FPL( t_9, l_imp, INTOBJ_INT(2) )
    t_7 = CALL_2ARGS( t_8, l_with, t_9 );
-   CHECK_FUNC_RESULT( t_7 );
-   CHECK_BOOL( t_7 );
+   CHECK_FUNC_RESULT( t_7 )
+   CHECK_BOOL( t_7 )
    t_6 = (Obj)(UInt)(t_7 != False);
    t_5 = t_6;
    if ( t_5 ) {
     t_10 = GF_IS__SUBSET__FLAGS;
-    C_ELM_LIST_FPL( t_11, l_imp, INTOBJ_INT(1) );
+    C_ELM_LIST_FPL( t_11, l_imp, INTOBJ_INT(1) )
     t_9 = CALL_2ARGS( t_10, l_with, t_11 );
-    CHECK_FUNC_RESULT( t_9 );
-    CHECK_BOOL( t_9 );
+    CHECK_FUNC_RESULT( t_9 )
+    CHECK_BOOL( t_9 )
     t_8 = (Obj)(UInt)(t_9 != False);
     t_7 = (Obj)(UInt)( ! ((Int)t_8) );
     t_5 = t_7;
@@ -290,9 +290,9 @@ static Obj  HdlrFunc3 (
     
     /* with := AND_FLAGS( with, imp[1] ); */
     t_6 = GF_AND__FLAGS;
-    C_ELM_LIST_FPL( t_7, l_imp, INTOBJ_INT(1) );
+    C_ELM_LIST_FPL( t_7, l_imp, INTOBJ_INT(1) )
     t_5 = CALL_2ARGS( t_6, l_with, t_7 );
-    CHECK_FUNC_RESULT( t_5 );
+    CHECK_FUNC_RESULT( t_5 )
     l_with = t_5;
     
     /* changed := true; */
@@ -310,16 +310,16 @@ static Obj  HdlrFunc3 (
  
  /* WITH_IMPS_FLAGS_CACHE[hash2] := flags; */
  t_1 = GC_WITH__IMPS__FLAGS__CACHE;
- CHECK_BOUND( t_1, "WITH_IMPS_FLAGS_CACHE" );
- CHECK_INT_POS( l_hash2 );
- C_ASS_LIST_FPL( t_1, l_hash2, a_flags );
+ CHECK_BOUND( t_1, "WITH_IMPS_FLAGS_CACHE" )
+ CHECK_INT_POS( l_hash2 )
+ C_ASS_LIST_FPL( t_1, l_hash2, a_flags )
  
  /* WITH_IMPS_FLAGS_CACHE[hash2 + 1] := with; */
  t_1 = GC_WITH__IMPS__FLAGS__CACHE;
- CHECK_BOUND( t_1, "WITH_IMPS_FLAGS_CACHE" );
- C_SUM_FIA( t_2, l_hash2, INTOBJ_INT(1) );
- CHECK_INT_POS( t_2 );
- C_ASS_LIST_FPL( t_1, t_2, l_with );
+ CHECK_BOUND( t_1, "WITH_IMPS_FLAGS_CACHE" )
+ C_SUM_FIA( t_2, l_hash2, INTOBJ_INT(1) )
+ CHECK_INT_POS( t_2 )
+ C_ASS_LIST_FPL( t_1, t_2, l_with )
  
  /* return with; */
  RES_BRK_CURR_STAT();
@@ -361,15 +361,15 @@ static Obj  HdlrFunc4 (
  /* if IS_FUNCTION( filter ) then */
  t_3 = GF_IS__FUNCTION;
  t_2 = CALL_1ARGS( t_3, a_filter );
- CHECK_FUNC_RESULT( t_2 );
- CHECK_BOOL( t_2 );
+ CHECK_FUNC_RESULT( t_2 )
+ CHECK_BOOL( t_2 )
  t_1 = (Obj)(UInt)(t_2 != False);
  if ( t_1 ) {
   
   /* flags := FLAGS_FILTER( filter ); */
   t_2 = GF_FLAGS__FILTER;
   t_1 = CALL_1ARGS( t_2, a_filter );
-  CHECK_FUNC_RESULT( t_1 );
+  CHECK_FUNC_RESULT( t_1 )
   l_flags = t_1;
   
  }
@@ -387,9 +387,9 @@ static Obj  HdlrFunc4 (
  t_5 = GF_TRUES__FLAGS;
  t_7 = GF_WITH__HIDDEN__IMPS__FLAGS;
  t_6 = CALL_1ARGS( t_7, l_flags );
- CHECK_FUNC_RESULT( t_6 );
+ CHECK_FUNC_RESULT( t_6 )
  t_4 = CALL_1ARGS( t_5, t_6 );
- CHECK_FUNC_RESULT( t_4 );
+ CHECK_FUNC_RESULT( t_4 )
  if ( IS_SMALL_LIST(t_4) ) {
   t_3 = (Obj)(UInt)1;
   t_1 = INTOBJ_INT(1);
@@ -413,17 +413,17 @@ static Obj  HdlrFunc4 (
   
   /* if IsBound( RANK_FILTERS[i] ) then */
   t_7 = GC_RANK__FILTERS;
-  CHECK_BOUND( t_7, "RANK_FILTERS" );
-  CHECK_INT_POS( l_i );
+  CHECK_BOUND( t_7, "RANK_FILTERS" )
+  CHECK_INT_POS( l_i )
   t_6 = C_ISB_LIST( t_7, l_i );
   t_5 = (Obj)(UInt)(t_6 != False);
   if ( t_5 ) {
    
    /* rank := rank + RANK_FILTERS[i]; */
    t_7 = GC_RANK__FILTERS;
-   CHECK_BOUND( t_7, "RANK_FILTERS" );
-   C_ELM_LIST_FPL( t_6, t_7, l_i );
-   C_SUM_FIA( t_5, l_rank, t_6 );
+   CHECK_BOUND( t_7, "RANK_FILTERS" )
+   C_ELM_LIST_FPL( t_6, t_7, l_i )
+   C_SUM_FIA( t_5, l_rank, t_6 )
    l_rank = t_5;
    
   }
@@ -432,7 +432,7 @@ static Obj  HdlrFunc4 (
   else {
    
    /* rank := rank + 1; */
-   C_SUM_FIA( t_5, l_rank, INTOBJ_INT(1) );
+   C_SUM_FIA( t_5, l_rank, INTOBJ_INT(1) )
    l_rank = t_5;
    
   }
@@ -474,15 +474,15 @@ static Obj  HdlrFunc5 (
  /* if IS_FUNCTION( filter ) then */
  t_3 = GF_IS__FUNCTION;
  t_2 = CALL_1ARGS( t_3, a_filter );
- CHECK_FUNC_RESULT( t_2 );
- CHECK_BOOL( t_2 );
+ CHECK_FUNC_RESULT( t_2 )
+ CHECK_BOOL( t_2 )
  t_1 = (Obj)(UInt)(t_2 != False);
  if ( t_1 ) {
   
   /* flags := FLAGS_FILTER( filter ); */
   t_2 = GF_FLAGS__FILTER;
   t_1 = CALL_1ARGS( t_2, a_filter );
-  CHECK_FUNC_RESULT( t_1 );
+  CHECK_FUNC_RESULT( t_1 )
   l_flags = t_1;
   
  }
@@ -499,25 +499,25 @@ static Obj  HdlrFunc5 (
  /* hash := HASH_FLAGS( flags ); */
  t_2 = GF_HASH__FLAGS;
  t_1 = CALL_1ARGS( t_2, l_flags );
- CHECK_FUNC_RESULT( t_1 );
+ CHECK_FUNC_RESULT( t_1 )
  l_hash = t_1;
  
  /* rank := RANK_FILTER( flags ); */
  t_2 = GF_RANK__FILTER;
  t_1 = CALL_1ARGS( t_2, l_flags );
- CHECK_FUNC_RESULT( t_1 );
+ CHECK_FUNC_RESULT( t_1 )
  l_rank = t_1;
  
  /* ADD_LIST( RANK_FILTER_LIST_CURRENT, hash ); */
  t_1 = GF_ADD__LIST;
  t_2 = GC_RANK__FILTER__LIST__CURRENT;
- CHECK_BOUND( t_2, "RANK_FILTER_LIST_CURRENT" );
+ CHECK_BOUND( t_2, "RANK_FILTER_LIST_CURRENT" )
  CALL_2ARGS( t_1, t_2, l_hash );
  
  /* ADD_LIST( RANK_FILTER_LIST_CURRENT, rank ); */
  t_1 = GF_ADD__LIST;
  t_2 = GC_RANK__FILTER__LIST__CURRENT;
- CHECK_BOUND( t_2, "RANK_FILTER_LIST_CURRENT" );
+ CHECK_BOUND( t_2, "RANK_FILTER_LIST_CURRENT" )
  CALL_2ARGS( t_1, t_2, l_rank );
  
  /* return rank; */
@@ -553,15 +553,15 @@ static Obj  HdlrFunc6 (
  /* if IS_FUNCTION( filter ) then */
  t_3 = GF_IS__FUNCTION;
  t_2 = CALL_1ARGS( t_3, a_filter );
- CHECK_FUNC_RESULT( t_2 );
- CHECK_BOOL( t_2 );
+ CHECK_FUNC_RESULT( t_2 )
+ CHECK_BOOL( t_2 )
  t_1 = (Obj)(UInt)(t_2 != False);
  if ( t_1 ) {
   
   /* flags := FLAGS_FILTER( filter ); */
   t_2 = GF_FLAGS__FILTER;
   t_1 = CALL_1ARGS( t_2, a_filter );
-  CHECK_FUNC_RESULT( t_1 );
+  CHECK_FUNC_RESULT( t_1 )
   l_flags = t_1;
   
  }
@@ -578,16 +578,16 @@ static Obj  HdlrFunc6 (
  /* hash := HASH_FLAGS( flags ); */
  t_2 = GF_HASH__FLAGS;
  t_1 = CALL_1ARGS( t_2, l_flags );
- CHECK_FUNC_RESULT( t_1 );
+ CHECK_FUNC_RESULT( t_1 )
  l_hash = t_1;
  
  /* if hash <> RANK_FILTER_LIST[RANK_FILTER_COUNT] then */
  t_3 = GC_RANK__FILTER__LIST;
- CHECK_BOUND( t_3, "RANK_FILTER_LIST" );
+ CHECK_BOUND( t_3, "RANK_FILTER_LIST" )
  t_4 = GC_RANK__FILTER__COUNT;
- CHECK_BOUND( t_4, "RANK_FILTER_COUNT" );
- CHECK_INT_POS( t_4 );
- C_ELM_LIST_FPL( t_2, t_3, t_4 );
+ CHECK_BOUND( t_4, "RANK_FILTER_COUNT" )
+ CHECK_INT_POS( t_4 )
+ C_ELM_LIST_FPL( t_2, t_3, t_4 )
  t_1 = (Obj)(UInt)( ! EQ( l_hash, t_2 ));
  if ( t_1 ) {
   
@@ -601,18 +601,18 @@ static Obj  HdlrFunc6 (
  
  /* RANK_FILTER_COUNT := RANK_FILTER_COUNT + 2; */
  t_2 = GC_RANK__FILTER__COUNT;
- CHECK_BOUND( t_2, "RANK_FILTER_COUNT" );
- C_SUM_FIA( t_1, t_2, INTOBJ_INT(2) );
+ CHECK_BOUND( t_2, "RANK_FILTER_COUNT" )
+ C_SUM_FIA( t_1, t_2, INTOBJ_INT(2) )
  AssGVar( G_RANK__FILTER__COUNT, t_1 );
  
  /* return RANK_FILTER_LIST[RANK_FILTER_COUNT - 1]; */
  t_2 = GC_RANK__FILTER__LIST;
- CHECK_BOUND( t_2, "RANK_FILTER_LIST" );
+ CHECK_BOUND( t_2, "RANK_FILTER_LIST" )
  t_4 = GC_RANK__FILTER__COUNT;
- CHECK_BOUND( t_4, "RANK_FILTER_COUNT" );
- C_DIFF_FIA( t_3, t_4, INTOBJ_INT(1) );
- CHECK_INT_POS( t_3 );
- C_ELM_LIST_FPL( t_1, t_2, t_3 );
+ CHECK_BOUND( t_4, "RANK_FILTER_COUNT" )
+ C_DIFF_FIA( t_3, t_4, INTOBJ_INT(1) )
+ CHECK_INT_POS( t_3 )
+ C_ELM_LIST_FPL( t_1, t_2, t_3 )
  RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
@@ -769,7 +769,7 @@ static Obj  HdlrFunc1 (
  
  /* RankFilter := RANK_FILTER; */
  t_1 = GC_RANK__FILTER;
- CHECK_BOUND( t_1, "RANK_FILTER" );
+ CHECK_BOUND( t_1, "RANK_FILTER" )
  AssGVar( G_RankFilter, t_1 );
  
  /* UNBIND_GLOBAL( "RANK_FILTER_STORE" ); */

--- a/src/c_methsel1.c
+++ b/src/c_methsel1.c
@@ -89,14 +89,14 @@ static Obj  HdlrFunc2 (
  /* methods := METHODS_OPERATION( operation, 0 ); */
  t_2 = GF_METHODS__OPERATION;
  t_1 = CALL_2ARGS( t_2, a_operation, INTOBJ_INT(0) );
- CHECK_FUNC_RESULT( t_1 );
+ CHECK_FUNC_RESULT( t_1 )
  l_methods = t_1;
  
  /* for i in [ 1, 5 .. LEN_LIST( methods ) - 3 ] do */
  t_7 = GF_LEN__LIST;
  t_6 = CALL_1ARGS( t_7, l_methods );
- CHECK_FUNC_RESULT( t_6 );
- C_DIFF_FIA( t_5, t_6, INTOBJ_INT(3) );
+ CHECK_FUNC_RESULT( t_6 )
+ C_DIFF_FIA( t_5, t_6, INTOBJ_INT(3) )
  t_4 = Range3Check( INTOBJ_INT(1), INTOBJ_INT(5), t_5 );
  if ( IS_SMALL_LIST(t_4) ) {
   t_3 = (Obj)(UInt)1;
@@ -120,19 +120,19 @@ static Obj  HdlrFunc2 (
   l_i = t_2;
   
   /* if methods[i](  ) then */
-  CHECK_INT_POS( l_i );
-  C_ELM_LIST_FPL( t_7, l_methods, l_i );
-  CHECK_FUNC( t_7 );
+  CHECK_INT_POS( l_i )
+  C_ELM_LIST_FPL( t_7, l_methods, l_i )
+  CHECK_FUNC( t_7 )
   t_6 = CALL_0ARGS( t_7 );
-  CHECK_FUNC_RESULT( t_6 );
-  CHECK_BOOL( t_6 );
+  CHECK_FUNC_RESULT( t_6 )
+  CHECK_BOOL( t_6 )
   t_5 = (Obj)(UInt)(t_6 != False);
   if ( t_5 ) {
    
    /* return methods[i + 1]; */
-   C_SUM_FIA( t_6, l_i, INTOBJ_INT(1) );
-   CHECK_INT_POS( t_6 );
-   C_ELM_LIST_FPL( t_5, l_methods, t_6 );
+   C_SUM_FIA( t_6, l_i, INTOBJ_INT(1) )
+   CHECK_INT_POS( t_6 )
+   C_ELM_LIST_FPL( t_5, l_methods, t_6 )
    RES_BRK_CURR_STAT();
    SWITCH_TO_OLD_FRAME(oldFrame);
    return t_5;
@@ -145,7 +145,7 @@ static Obj  HdlrFunc2 (
  
  /* return fail; */
  t_1 = GC_fail;
- CHECK_BOUND( t_1, "fail" );
+ CHECK_BOUND( t_1, "fail" )
  RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
@@ -186,14 +186,14 @@ static Obj  HdlrFunc3 (
  /* methods := METHODS_OPERATION( operation, 1 ); */
  t_2 = GF_METHODS__OPERATION;
  t_1 = CALL_2ARGS( t_2, a_operation, INTOBJ_INT(1) );
- CHECK_FUNC_RESULT( t_1 );
+ CHECK_FUNC_RESULT( t_1 )
  l_methods = t_1;
  
  /* for i in [ 1, 6 .. LEN_LIST( methods ) - 4 ] do */
  t_7 = GF_LEN__LIST;
  t_6 = CALL_1ARGS( t_7, l_methods );
- CHECK_FUNC_RESULT( t_6 );
- C_DIFF_FIA( t_5, t_6, INTOBJ_INT(4) );
+ CHECK_FUNC_RESULT( t_6 )
+ C_DIFF_FIA( t_5, t_6, INTOBJ_INT(4) )
  t_4 = Range3Check( INTOBJ_INT(1), INTOBJ_INT(6), t_5 );
  if ( IS_SMALL_LIST(t_4) ) {
   t_3 = (Obj)(UInt)1;
@@ -219,31 +219,31 @@ static Obj  HdlrFunc3 (
   /* if IS_SUBSET_FLAGS( type1![2], methods[i + 1] ) and methods[i]( type1![1] ) then */
   t_8 = GF_IS__SUBSET__FLAGS;
   C_ELM_POSOBJ_NLE( t_9, a_type1, 2 );
-  C_SUM_FIA( t_11, l_i, INTOBJ_INT(1) );
-  CHECK_INT_POS( t_11 );
-  C_ELM_LIST_FPL( t_10, l_methods, t_11 );
+  C_SUM_FIA( t_11, l_i, INTOBJ_INT(1) )
+  CHECK_INT_POS( t_11 )
+  C_ELM_LIST_FPL( t_10, l_methods, t_11 )
   t_7 = CALL_2ARGS( t_8, t_9, t_10 );
-  CHECK_FUNC_RESULT( t_7 );
-  CHECK_BOOL( t_7 );
+  CHECK_FUNC_RESULT( t_7 )
+  CHECK_BOOL( t_7 )
   t_6 = (Obj)(UInt)(t_7 != False);
   t_5 = t_6;
   if ( t_5 ) {
-   CHECK_INT_POS( l_i );
-   C_ELM_LIST_FPL( t_9, l_methods, l_i );
-   CHECK_FUNC( t_9 );
+   CHECK_INT_POS( l_i )
+   C_ELM_LIST_FPL( t_9, l_methods, l_i )
+   CHECK_FUNC( t_9 )
    C_ELM_POSOBJ_NLE( t_10, a_type1, 1 );
    t_8 = CALL_1ARGS( t_9, t_10 );
-   CHECK_FUNC_RESULT( t_8 );
-   CHECK_BOOL( t_8 );
+   CHECK_FUNC_RESULT( t_8 )
+   CHECK_BOOL( t_8 )
    t_7 = (Obj)(UInt)(t_8 != False);
    t_5 = t_7;
   }
   if ( t_5 ) {
    
    /* return methods[i + 2]; */
-   C_SUM_FIA( t_6, l_i, INTOBJ_INT(2) );
-   CHECK_INT_POS( t_6 );
-   C_ELM_LIST_FPL( t_5, l_methods, t_6 );
+   C_SUM_FIA( t_6, l_i, INTOBJ_INT(2) )
+   CHECK_INT_POS( t_6 )
+   C_ELM_LIST_FPL( t_5, l_methods, t_6 )
    RES_BRK_CURR_STAT();
    SWITCH_TO_OLD_FRAME(oldFrame);
    return t_5;
@@ -256,7 +256,7 @@ static Obj  HdlrFunc3 (
  
  /* return fail; */
  t_1 = GC_fail;
- CHECK_BOUND( t_1, "fail" );
+ CHECK_BOUND( t_1, "fail" )
  RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
@@ -300,14 +300,14 @@ static Obj  HdlrFunc4 (
  /* methods := METHODS_OPERATION( operation, 2 ); */
  t_2 = GF_METHODS__OPERATION;
  t_1 = CALL_2ARGS( t_2, a_operation, INTOBJ_INT(2) );
- CHECK_FUNC_RESULT( t_1 );
+ CHECK_FUNC_RESULT( t_1 )
  l_methods = t_1;
  
  /* for i in [ 1, 7 .. LEN_LIST( methods ) - 5 ] do */
  t_7 = GF_LEN__LIST;
  t_6 = CALL_1ARGS( t_7, l_methods );
- CHECK_FUNC_RESULT( t_6 );
- C_DIFF_FIA( t_5, t_6, INTOBJ_INT(5) );
+ CHECK_FUNC_RESULT( t_6 )
+ C_DIFF_FIA( t_5, t_6, INTOBJ_INT(5) )
  t_4 = Range3Check( INTOBJ_INT(1), INTOBJ_INT(7), t_5 );
  if ( IS_SMALL_LIST(t_4) ) {
   t_3 = (Obj)(UInt)1;
@@ -333,45 +333,45 @@ static Obj  HdlrFunc4 (
   /* if IS_SUBSET_FLAGS( type1![2], methods[i + 1] ) and IS_SUBSET_FLAGS( type2![2], methods[i + 2] ) and methods[i]( type1![1], type2![1] ) then */
   t_9 = GF_IS__SUBSET__FLAGS;
   C_ELM_POSOBJ_NLE( t_10, a_type1, 2 );
-  C_SUM_FIA( t_12, l_i, INTOBJ_INT(1) );
-  CHECK_INT_POS( t_12 );
-  C_ELM_LIST_FPL( t_11, l_methods, t_12 );
+  C_SUM_FIA( t_12, l_i, INTOBJ_INT(1) )
+  CHECK_INT_POS( t_12 )
+  C_ELM_LIST_FPL( t_11, l_methods, t_12 )
   t_8 = CALL_2ARGS( t_9, t_10, t_11 );
-  CHECK_FUNC_RESULT( t_8 );
-  CHECK_BOOL( t_8 );
+  CHECK_FUNC_RESULT( t_8 )
+  CHECK_BOOL( t_8 )
   t_7 = (Obj)(UInt)(t_8 != False);
   t_6 = t_7;
   if ( t_6 ) {
    t_10 = GF_IS__SUBSET__FLAGS;
    C_ELM_POSOBJ_NLE( t_11, a_type2, 2 );
-   C_SUM_FIA( t_13, l_i, INTOBJ_INT(2) );
-   CHECK_INT_POS( t_13 );
-   C_ELM_LIST_FPL( t_12, l_methods, t_13 );
+   C_SUM_FIA( t_13, l_i, INTOBJ_INT(2) )
+   CHECK_INT_POS( t_13 )
+   C_ELM_LIST_FPL( t_12, l_methods, t_13 )
    t_9 = CALL_2ARGS( t_10, t_11, t_12 );
-   CHECK_FUNC_RESULT( t_9 );
-   CHECK_BOOL( t_9 );
+   CHECK_FUNC_RESULT( t_9 )
+   CHECK_BOOL( t_9 )
    t_8 = (Obj)(UInt)(t_9 != False);
    t_6 = t_8;
   }
   t_5 = t_6;
   if ( t_5 ) {
-   CHECK_INT_POS( l_i );
-   C_ELM_LIST_FPL( t_9, l_methods, l_i );
-   CHECK_FUNC( t_9 );
+   CHECK_INT_POS( l_i )
+   C_ELM_LIST_FPL( t_9, l_methods, l_i )
+   CHECK_FUNC( t_9 )
    C_ELM_POSOBJ_NLE( t_10, a_type1, 1 );
    C_ELM_POSOBJ_NLE( t_11, a_type2, 1 );
    t_8 = CALL_2ARGS( t_9, t_10, t_11 );
-   CHECK_FUNC_RESULT( t_8 );
-   CHECK_BOOL( t_8 );
+   CHECK_FUNC_RESULT( t_8 )
+   CHECK_BOOL( t_8 )
    t_7 = (Obj)(UInt)(t_8 != False);
    t_5 = t_7;
   }
   if ( t_5 ) {
    
    /* return methods[i + 3]; */
-   C_SUM_FIA( t_6, l_i, INTOBJ_INT(3) );
-   CHECK_INT_POS( t_6 );
-   C_ELM_LIST_FPL( t_5, l_methods, t_6 );
+   C_SUM_FIA( t_6, l_i, INTOBJ_INT(3) )
+   CHECK_INT_POS( t_6 )
+   C_ELM_LIST_FPL( t_5, l_methods, t_6 )
    RES_BRK_CURR_STAT();
    SWITCH_TO_OLD_FRAME(oldFrame);
    return t_5;
@@ -384,7 +384,7 @@ static Obj  HdlrFunc4 (
  
  /* return fail; */
  t_1 = GC_fail;
- CHECK_BOUND( t_1, "fail" );
+ CHECK_BOUND( t_1, "fail" )
  RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
@@ -430,14 +430,14 @@ static Obj  HdlrFunc5 (
  /* methods := METHODS_OPERATION( operation, 3 ); */
  t_2 = GF_METHODS__OPERATION;
  t_1 = CALL_2ARGS( t_2, a_operation, INTOBJ_INT(3) );
- CHECK_FUNC_RESULT( t_1 );
+ CHECK_FUNC_RESULT( t_1 )
  l_methods = t_1;
  
  /* for i in [ 1, 8 .. LEN_LIST( methods ) - 6 ] do */
  t_7 = GF_LEN__LIST;
  t_6 = CALL_1ARGS( t_7, l_methods );
- CHECK_FUNC_RESULT( t_6 );
- C_DIFF_FIA( t_5, t_6, INTOBJ_INT(6) );
+ CHECK_FUNC_RESULT( t_6 )
+ C_DIFF_FIA( t_5, t_6, INTOBJ_INT(6) )
  t_4 = Range3Check( INTOBJ_INT(1), INTOBJ_INT(8), t_5 );
  if ( IS_SMALL_LIST(t_4) ) {
   t_3 = (Obj)(UInt)1;
@@ -463,23 +463,23 @@ static Obj  HdlrFunc5 (
   /* if IS_SUBSET_FLAGS( type1![2], methods[i + 1] ) and IS_SUBSET_FLAGS( type2![2], methods[i + 2] ) and IS_SUBSET_FLAGS( type3![2], methods[i + 3] ) and methods[i]( type1![1], type2![1], type3![1] ) then */
   t_10 = GF_IS__SUBSET__FLAGS;
   C_ELM_POSOBJ_NLE( t_11, a_type1, 2 );
-  C_SUM_FIA( t_13, l_i, INTOBJ_INT(1) );
-  CHECK_INT_POS( t_13 );
-  C_ELM_LIST_FPL( t_12, l_methods, t_13 );
+  C_SUM_FIA( t_13, l_i, INTOBJ_INT(1) )
+  CHECK_INT_POS( t_13 )
+  C_ELM_LIST_FPL( t_12, l_methods, t_13 )
   t_9 = CALL_2ARGS( t_10, t_11, t_12 );
-  CHECK_FUNC_RESULT( t_9 );
-  CHECK_BOOL( t_9 );
+  CHECK_FUNC_RESULT( t_9 )
+  CHECK_BOOL( t_9 )
   t_8 = (Obj)(UInt)(t_9 != False);
   t_7 = t_8;
   if ( t_7 ) {
    t_11 = GF_IS__SUBSET__FLAGS;
    C_ELM_POSOBJ_NLE( t_12, a_type2, 2 );
-   C_SUM_FIA( t_14, l_i, INTOBJ_INT(2) );
-   CHECK_INT_POS( t_14 );
-   C_ELM_LIST_FPL( t_13, l_methods, t_14 );
+   C_SUM_FIA( t_14, l_i, INTOBJ_INT(2) )
+   CHECK_INT_POS( t_14 )
+   C_ELM_LIST_FPL( t_13, l_methods, t_14 )
    t_10 = CALL_2ARGS( t_11, t_12, t_13 );
-   CHECK_FUNC_RESULT( t_10 );
-   CHECK_BOOL( t_10 );
+   CHECK_FUNC_RESULT( t_10 )
+   CHECK_BOOL( t_10 )
    t_9 = (Obj)(UInt)(t_10 != False);
    t_7 = t_9;
   }
@@ -487,35 +487,35 @@ static Obj  HdlrFunc5 (
   if ( t_6 ) {
    t_10 = GF_IS__SUBSET__FLAGS;
    C_ELM_POSOBJ_NLE( t_11, a_type3, 2 );
-   C_SUM_FIA( t_13, l_i, INTOBJ_INT(3) );
-   CHECK_INT_POS( t_13 );
-   C_ELM_LIST_FPL( t_12, l_methods, t_13 );
+   C_SUM_FIA( t_13, l_i, INTOBJ_INT(3) )
+   CHECK_INT_POS( t_13 )
+   C_ELM_LIST_FPL( t_12, l_methods, t_13 )
    t_9 = CALL_2ARGS( t_10, t_11, t_12 );
-   CHECK_FUNC_RESULT( t_9 );
-   CHECK_BOOL( t_9 );
+   CHECK_FUNC_RESULT( t_9 )
+   CHECK_BOOL( t_9 )
    t_8 = (Obj)(UInt)(t_9 != False);
    t_6 = t_8;
   }
   t_5 = t_6;
   if ( t_5 ) {
-   CHECK_INT_POS( l_i );
-   C_ELM_LIST_FPL( t_9, l_methods, l_i );
-   CHECK_FUNC( t_9 );
+   CHECK_INT_POS( l_i )
+   C_ELM_LIST_FPL( t_9, l_methods, l_i )
+   CHECK_FUNC( t_9 )
    C_ELM_POSOBJ_NLE( t_10, a_type1, 1 );
    C_ELM_POSOBJ_NLE( t_11, a_type2, 1 );
    C_ELM_POSOBJ_NLE( t_12, a_type3, 1 );
    t_8 = CALL_3ARGS( t_9, t_10, t_11, t_12 );
-   CHECK_FUNC_RESULT( t_8 );
-   CHECK_BOOL( t_8 );
+   CHECK_FUNC_RESULT( t_8 )
+   CHECK_BOOL( t_8 )
    t_7 = (Obj)(UInt)(t_8 != False);
    t_5 = t_7;
   }
   if ( t_5 ) {
    
    /* return methods[i + 4]; */
-   C_SUM_FIA( t_6, l_i, INTOBJ_INT(4) );
-   CHECK_INT_POS( t_6 );
-   C_ELM_LIST_FPL( t_5, l_methods, t_6 );
+   C_SUM_FIA( t_6, l_i, INTOBJ_INT(4) )
+   CHECK_INT_POS( t_6 )
+   C_ELM_LIST_FPL( t_5, l_methods, t_6 )
    RES_BRK_CURR_STAT();
    SWITCH_TO_OLD_FRAME(oldFrame);
    return t_5;
@@ -528,7 +528,7 @@ static Obj  HdlrFunc5 (
  
  /* return fail; */
  t_1 = GC_fail;
- CHECK_BOUND( t_1, "fail" );
+ CHECK_BOUND( t_1, "fail" )
  RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
@@ -576,14 +576,14 @@ static Obj  HdlrFunc6 (
  /* methods := METHODS_OPERATION( operation, 4 ); */
  t_2 = GF_METHODS__OPERATION;
  t_1 = CALL_2ARGS( t_2, a_operation, INTOBJ_INT(4) );
- CHECK_FUNC_RESULT( t_1 );
+ CHECK_FUNC_RESULT( t_1 )
  l_methods = t_1;
  
  /* for i in [ 1, 9 .. LEN_LIST( methods ) - 7 ] do */
  t_7 = GF_LEN__LIST;
  t_6 = CALL_1ARGS( t_7, l_methods );
- CHECK_FUNC_RESULT( t_6 );
- C_DIFF_FIA( t_5, t_6, INTOBJ_INT(7) );
+ CHECK_FUNC_RESULT( t_6 )
+ C_DIFF_FIA( t_5, t_6, INTOBJ_INT(7) )
  t_4 = Range3Check( INTOBJ_INT(1), INTOBJ_INT(9), t_5 );
  if ( IS_SMALL_LIST(t_4) ) {
   t_3 = (Obj)(UInt)1;
@@ -610,23 +610,23 @@ static Obj  HdlrFunc6 (
    type4![1] ) then */
   t_11 = GF_IS__SUBSET__FLAGS;
   C_ELM_POSOBJ_NLE( t_12, a_type1, 2 );
-  C_SUM_FIA( t_14, l_i, INTOBJ_INT(1) );
-  CHECK_INT_POS( t_14 );
-  C_ELM_LIST_FPL( t_13, l_methods, t_14 );
+  C_SUM_FIA( t_14, l_i, INTOBJ_INT(1) )
+  CHECK_INT_POS( t_14 )
+  C_ELM_LIST_FPL( t_13, l_methods, t_14 )
   t_10 = CALL_2ARGS( t_11, t_12, t_13 );
-  CHECK_FUNC_RESULT( t_10 );
-  CHECK_BOOL( t_10 );
+  CHECK_FUNC_RESULT( t_10 )
+  CHECK_BOOL( t_10 )
   t_9 = (Obj)(UInt)(t_10 != False);
   t_8 = t_9;
   if ( t_8 ) {
    t_12 = GF_IS__SUBSET__FLAGS;
    C_ELM_POSOBJ_NLE( t_13, a_type2, 2 );
-   C_SUM_FIA( t_15, l_i, INTOBJ_INT(2) );
-   CHECK_INT_POS( t_15 );
-   C_ELM_LIST_FPL( t_14, l_methods, t_15 );
+   C_SUM_FIA( t_15, l_i, INTOBJ_INT(2) )
+   CHECK_INT_POS( t_15 )
+   C_ELM_LIST_FPL( t_14, l_methods, t_15 )
    t_11 = CALL_2ARGS( t_12, t_13, t_14 );
-   CHECK_FUNC_RESULT( t_11 );
-   CHECK_BOOL( t_11 );
+   CHECK_FUNC_RESULT( t_11 )
+   CHECK_BOOL( t_11 )
    t_10 = (Obj)(UInt)(t_11 != False);
    t_8 = t_10;
   }
@@ -634,12 +634,12 @@ static Obj  HdlrFunc6 (
   if ( t_7 ) {
    t_11 = GF_IS__SUBSET__FLAGS;
    C_ELM_POSOBJ_NLE( t_12, a_type3, 2 );
-   C_SUM_FIA( t_14, l_i, INTOBJ_INT(3) );
-   CHECK_INT_POS( t_14 );
-   C_ELM_LIST_FPL( t_13, l_methods, t_14 );
+   C_SUM_FIA( t_14, l_i, INTOBJ_INT(3) )
+   CHECK_INT_POS( t_14 )
+   C_ELM_LIST_FPL( t_13, l_methods, t_14 )
    t_10 = CALL_2ARGS( t_11, t_12, t_13 );
-   CHECK_FUNC_RESULT( t_10 );
-   CHECK_BOOL( t_10 );
+   CHECK_FUNC_RESULT( t_10 )
+   CHECK_BOOL( t_10 )
    t_9 = (Obj)(UInt)(t_10 != False);
    t_7 = t_9;
   }
@@ -647,36 +647,36 @@ static Obj  HdlrFunc6 (
   if ( t_6 ) {
    t_10 = GF_IS__SUBSET__FLAGS;
    C_ELM_POSOBJ_NLE( t_11, a_type4, 2 );
-   C_SUM_FIA( t_13, l_i, INTOBJ_INT(4) );
-   CHECK_INT_POS( t_13 );
-   C_ELM_LIST_FPL( t_12, l_methods, t_13 );
+   C_SUM_FIA( t_13, l_i, INTOBJ_INT(4) )
+   CHECK_INT_POS( t_13 )
+   C_ELM_LIST_FPL( t_12, l_methods, t_13 )
    t_9 = CALL_2ARGS( t_10, t_11, t_12 );
-   CHECK_FUNC_RESULT( t_9 );
-   CHECK_BOOL( t_9 );
+   CHECK_FUNC_RESULT( t_9 )
+   CHECK_BOOL( t_9 )
    t_8 = (Obj)(UInt)(t_9 != False);
    t_6 = t_8;
   }
   t_5 = t_6;
   if ( t_5 ) {
-   CHECK_INT_POS( l_i );
-   C_ELM_LIST_FPL( t_9, l_methods, l_i );
-   CHECK_FUNC( t_9 );
+   CHECK_INT_POS( l_i )
+   C_ELM_LIST_FPL( t_9, l_methods, l_i )
+   CHECK_FUNC( t_9 )
    C_ELM_POSOBJ_NLE( t_10, a_type1, 1 );
    C_ELM_POSOBJ_NLE( t_11, a_type2, 1 );
    C_ELM_POSOBJ_NLE( t_12, a_type3, 1 );
    C_ELM_POSOBJ_NLE( t_13, a_type4, 1 );
    t_8 = CALL_4ARGS( t_9, t_10, t_11, t_12, t_13 );
-   CHECK_FUNC_RESULT( t_8 );
-   CHECK_BOOL( t_8 );
+   CHECK_FUNC_RESULT( t_8 )
+   CHECK_BOOL( t_8 )
    t_7 = (Obj)(UInt)(t_8 != False);
    t_5 = t_7;
   }
   if ( t_5 ) {
    
    /* return methods[i + 5]; */
-   C_SUM_FIA( t_6, l_i, INTOBJ_INT(5) );
-   CHECK_INT_POS( t_6 );
-   C_ELM_LIST_FPL( t_5, l_methods, t_6 );
+   C_SUM_FIA( t_6, l_i, INTOBJ_INT(5) )
+   CHECK_INT_POS( t_6 )
+   C_ELM_LIST_FPL( t_5, l_methods, t_6 )
    RES_BRK_CURR_STAT();
    SWITCH_TO_OLD_FRAME(oldFrame);
    return t_5;
@@ -689,7 +689,7 @@ static Obj  HdlrFunc6 (
  
  /* return fail; */
  t_1 = GC_fail;
- CHECK_BOUND( t_1, "fail" );
+ CHECK_BOUND( t_1, "fail" )
  RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
@@ -739,14 +739,14 @@ static Obj  HdlrFunc7 (
  /* methods := METHODS_OPERATION( operation, 5 ); */
  t_2 = GF_METHODS__OPERATION;
  t_1 = CALL_2ARGS( t_2, a_operation, INTOBJ_INT(5) );
- CHECK_FUNC_RESULT( t_1 );
+ CHECK_FUNC_RESULT( t_1 )
  l_methods = t_1;
  
  /* for i in [ 1, 10 .. LEN_LIST( methods ) - 8 ] do */
  t_7 = GF_LEN__LIST;
  t_6 = CALL_1ARGS( t_7, l_methods );
- CHECK_FUNC_RESULT( t_6 );
- C_DIFF_FIA( t_5, t_6, INTOBJ_INT(8) );
+ CHECK_FUNC_RESULT( t_6 )
+ C_DIFF_FIA( t_5, t_6, INTOBJ_INT(8) )
  t_4 = Range3Check( INTOBJ_INT(1), INTOBJ_INT(10), t_5 );
  if ( IS_SMALL_LIST(t_4) ) {
   t_3 = (Obj)(UInt)1;
@@ -773,23 +773,23 @@ static Obj  HdlrFunc7 (
 and methods[i]( type1![1], type2![1], type3![1], type4![1], type5![1] ) then */
   t_12 = GF_IS__SUBSET__FLAGS;
   C_ELM_POSOBJ_NLE( t_13, a_type1, 2 );
-  C_SUM_FIA( t_15, l_i, INTOBJ_INT(1) );
-  CHECK_INT_POS( t_15 );
-  C_ELM_LIST_FPL( t_14, l_methods, t_15 );
+  C_SUM_FIA( t_15, l_i, INTOBJ_INT(1) )
+  CHECK_INT_POS( t_15 )
+  C_ELM_LIST_FPL( t_14, l_methods, t_15 )
   t_11 = CALL_2ARGS( t_12, t_13, t_14 );
-  CHECK_FUNC_RESULT( t_11 );
-  CHECK_BOOL( t_11 );
+  CHECK_FUNC_RESULT( t_11 )
+  CHECK_BOOL( t_11 )
   t_10 = (Obj)(UInt)(t_11 != False);
   t_9 = t_10;
   if ( t_9 ) {
    t_13 = GF_IS__SUBSET__FLAGS;
    C_ELM_POSOBJ_NLE( t_14, a_type2, 2 );
-   C_SUM_FIA( t_16, l_i, INTOBJ_INT(2) );
-   CHECK_INT_POS( t_16 );
-   C_ELM_LIST_FPL( t_15, l_methods, t_16 );
+   C_SUM_FIA( t_16, l_i, INTOBJ_INT(2) )
+   CHECK_INT_POS( t_16 )
+   C_ELM_LIST_FPL( t_15, l_methods, t_16 )
    t_12 = CALL_2ARGS( t_13, t_14, t_15 );
-   CHECK_FUNC_RESULT( t_12 );
-   CHECK_BOOL( t_12 );
+   CHECK_FUNC_RESULT( t_12 )
+   CHECK_BOOL( t_12 )
    t_11 = (Obj)(UInt)(t_12 != False);
    t_9 = t_11;
   }
@@ -797,12 +797,12 @@ and methods[i]( type1![1], type2![1], type3![1], type4![1], type5![1] ) then */
   if ( t_8 ) {
    t_12 = GF_IS__SUBSET__FLAGS;
    C_ELM_POSOBJ_NLE( t_13, a_type3, 2 );
-   C_SUM_FIA( t_15, l_i, INTOBJ_INT(3) );
-   CHECK_INT_POS( t_15 );
-   C_ELM_LIST_FPL( t_14, l_methods, t_15 );
+   C_SUM_FIA( t_15, l_i, INTOBJ_INT(3) )
+   CHECK_INT_POS( t_15 )
+   C_ELM_LIST_FPL( t_14, l_methods, t_15 )
    t_11 = CALL_2ARGS( t_12, t_13, t_14 );
-   CHECK_FUNC_RESULT( t_11 );
-   CHECK_BOOL( t_11 );
+   CHECK_FUNC_RESULT( t_11 )
+   CHECK_BOOL( t_11 )
    t_10 = (Obj)(UInt)(t_11 != False);
    t_8 = t_10;
   }
@@ -810,12 +810,12 @@ and methods[i]( type1![1], type2![1], type3![1], type4![1], type5![1] ) then */
   if ( t_7 ) {
    t_11 = GF_IS__SUBSET__FLAGS;
    C_ELM_POSOBJ_NLE( t_12, a_type4, 2 );
-   C_SUM_FIA( t_14, l_i, INTOBJ_INT(4) );
-   CHECK_INT_POS( t_14 );
-   C_ELM_LIST_FPL( t_13, l_methods, t_14 );
+   C_SUM_FIA( t_14, l_i, INTOBJ_INT(4) )
+   CHECK_INT_POS( t_14 )
+   C_ELM_LIST_FPL( t_13, l_methods, t_14 )
    t_10 = CALL_2ARGS( t_11, t_12, t_13 );
-   CHECK_FUNC_RESULT( t_10 );
-   CHECK_BOOL( t_10 );
+   CHECK_FUNC_RESULT( t_10 )
+   CHECK_BOOL( t_10 )
    t_9 = (Obj)(UInt)(t_10 != False);
    t_7 = t_9;
   }
@@ -823,37 +823,37 @@ and methods[i]( type1![1], type2![1], type3![1], type4![1], type5![1] ) then */
   if ( t_6 ) {
    t_10 = GF_IS__SUBSET__FLAGS;
    C_ELM_POSOBJ_NLE( t_11, a_type5, 2 );
-   C_SUM_FIA( t_13, l_i, INTOBJ_INT(5) );
-   CHECK_INT_POS( t_13 );
-   C_ELM_LIST_FPL( t_12, l_methods, t_13 );
+   C_SUM_FIA( t_13, l_i, INTOBJ_INT(5) )
+   CHECK_INT_POS( t_13 )
+   C_ELM_LIST_FPL( t_12, l_methods, t_13 )
    t_9 = CALL_2ARGS( t_10, t_11, t_12 );
-   CHECK_FUNC_RESULT( t_9 );
-   CHECK_BOOL( t_9 );
+   CHECK_FUNC_RESULT( t_9 )
+   CHECK_BOOL( t_9 )
    t_8 = (Obj)(UInt)(t_9 != False);
    t_6 = t_8;
   }
   t_5 = t_6;
   if ( t_5 ) {
-   CHECK_INT_POS( l_i );
-   C_ELM_LIST_FPL( t_9, l_methods, l_i );
-   CHECK_FUNC( t_9 );
+   CHECK_INT_POS( l_i )
+   C_ELM_LIST_FPL( t_9, l_methods, l_i )
+   CHECK_FUNC( t_9 )
    C_ELM_POSOBJ_NLE( t_10, a_type1, 1 );
    C_ELM_POSOBJ_NLE( t_11, a_type2, 1 );
    C_ELM_POSOBJ_NLE( t_12, a_type3, 1 );
    C_ELM_POSOBJ_NLE( t_13, a_type4, 1 );
    C_ELM_POSOBJ_NLE( t_14, a_type5, 1 );
    t_8 = CALL_5ARGS( t_9, t_10, t_11, t_12, t_13, t_14 );
-   CHECK_FUNC_RESULT( t_8 );
-   CHECK_BOOL( t_8 );
+   CHECK_FUNC_RESULT( t_8 )
+   CHECK_BOOL( t_8 )
    t_7 = (Obj)(UInt)(t_8 != False);
    t_5 = t_7;
   }
   if ( t_5 ) {
    
    /* return methods[i + 6]; */
-   C_SUM_FIA( t_6, l_i, INTOBJ_INT(6) );
-   CHECK_INT_POS( t_6 );
-   C_ELM_LIST_FPL( t_5, l_methods, t_6 );
+   C_SUM_FIA( t_6, l_i, INTOBJ_INT(6) )
+   CHECK_INT_POS( t_6 )
+   C_ELM_LIST_FPL( t_5, l_methods, t_6 )
    RES_BRK_CURR_STAT();
    SWITCH_TO_OLD_FRAME(oldFrame);
    return t_5;
@@ -866,7 +866,7 @@ and methods[i]( type1![1], type2![1], type3![1], type4![1], type5![1] ) then */
  
  /* return fail; */
  t_1 = GC_fail;
- CHECK_BOUND( t_1, "fail" );
+ CHECK_BOUND( t_1, "fail" )
  RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
@@ -910,7 +910,7 @@ static Obj  HdlrFunc8 (
  Obj t_17 = 0;
  Bag oldFrame;
  OLD_BRK_CURR_STAT
- CHECK_NR_ARGS( 7, args );
+ CHECK_NR_ARGS( 7, args )
  a_operation = ELM_PLIST( args, 1 );
  a_type1 = ELM_PLIST( args, 2 );
  a_type2 = ELM_PLIST( args, 3 );
@@ -927,14 +927,14 @@ static Obj  HdlrFunc8 (
  /* methods := METHODS_OPERATION( operation, 6 ); */
  t_2 = GF_METHODS__OPERATION;
  t_1 = CALL_2ARGS( t_2, a_operation, INTOBJ_INT(6) );
- CHECK_FUNC_RESULT( t_1 );
+ CHECK_FUNC_RESULT( t_1 )
  l_methods = t_1;
  
  /* for i in [ 1, 11 .. LEN_LIST( methods ) - 9 ] do */
  t_7 = GF_LEN__LIST;
  t_6 = CALL_1ARGS( t_7, l_methods );
- CHECK_FUNC_RESULT( t_6 );
- C_DIFF_FIA( t_5, t_6, INTOBJ_INT(9) );
+ CHECK_FUNC_RESULT( t_6 )
+ C_DIFF_FIA( t_5, t_6, INTOBJ_INT(9) )
  t_4 = Range3Check( INTOBJ_INT(1), INTOBJ_INT(11), t_5 );
  if ( IS_SMALL_LIST(t_4) ) {
   t_3 = (Obj)(UInt)1;
@@ -961,23 +961,23 @@ static Obj  HdlrFunc8 (
   and IS_SUBSET_FLAGS( type6![2], methods[i + 6] ) and methods[i]( type1![1], type2![1], type3![1], type4![1], type5![1], type6![1] ) then */
   t_13 = GF_IS__SUBSET__FLAGS;
   C_ELM_POSOBJ_NLE( t_14, a_type1, 2 );
-  C_SUM_FIA( t_16, l_i, INTOBJ_INT(1) );
-  CHECK_INT_POS( t_16 );
-  C_ELM_LIST_FPL( t_15, l_methods, t_16 );
+  C_SUM_FIA( t_16, l_i, INTOBJ_INT(1) )
+  CHECK_INT_POS( t_16 )
+  C_ELM_LIST_FPL( t_15, l_methods, t_16 )
   t_12 = CALL_2ARGS( t_13, t_14, t_15 );
-  CHECK_FUNC_RESULT( t_12 );
-  CHECK_BOOL( t_12 );
+  CHECK_FUNC_RESULT( t_12 )
+  CHECK_BOOL( t_12 )
   t_11 = (Obj)(UInt)(t_12 != False);
   t_10 = t_11;
   if ( t_10 ) {
    t_14 = GF_IS__SUBSET__FLAGS;
    C_ELM_POSOBJ_NLE( t_15, a_type2, 2 );
-   C_SUM_FIA( t_17, l_i, INTOBJ_INT(2) );
-   CHECK_INT_POS( t_17 );
-   C_ELM_LIST_FPL( t_16, l_methods, t_17 );
+   C_SUM_FIA( t_17, l_i, INTOBJ_INT(2) )
+   CHECK_INT_POS( t_17 )
+   C_ELM_LIST_FPL( t_16, l_methods, t_17 )
    t_13 = CALL_2ARGS( t_14, t_15, t_16 );
-   CHECK_FUNC_RESULT( t_13 );
-   CHECK_BOOL( t_13 );
+   CHECK_FUNC_RESULT( t_13 )
+   CHECK_BOOL( t_13 )
    t_12 = (Obj)(UInt)(t_13 != False);
    t_10 = t_12;
   }
@@ -985,12 +985,12 @@ static Obj  HdlrFunc8 (
   if ( t_9 ) {
    t_13 = GF_IS__SUBSET__FLAGS;
    C_ELM_POSOBJ_NLE( t_14, a_type3, 2 );
-   C_SUM_FIA( t_16, l_i, INTOBJ_INT(3) );
-   CHECK_INT_POS( t_16 );
-   C_ELM_LIST_FPL( t_15, l_methods, t_16 );
+   C_SUM_FIA( t_16, l_i, INTOBJ_INT(3) )
+   CHECK_INT_POS( t_16 )
+   C_ELM_LIST_FPL( t_15, l_methods, t_16 )
    t_12 = CALL_2ARGS( t_13, t_14, t_15 );
-   CHECK_FUNC_RESULT( t_12 );
-   CHECK_BOOL( t_12 );
+   CHECK_FUNC_RESULT( t_12 )
+   CHECK_BOOL( t_12 )
    t_11 = (Obj)(UInt)(t_12 != False);
    t_9 = t_11;
   }
@@ -998,12 +998,12 @@ static Obj  HdlrFunc8 (
   if ( t_8 ) {
    t_12 = GF_IS__SUBSET__FLAGS;
    C_ELM_POSOBJ_NLE( t_13, a_type4, 2 );
-   C_SUM_FIA( t_15, l_i, INTOBJ_INT(4) );
-   CHECK_INT_POS( t_15 );
-   C_ELM_LIST_FPL( t_14, l_methods, t_15 );
+   C_SUM_FIA( t_15, l_i, INTOBJ_INT(4) )
+   CHECK_INT_POS( t_15 )
+   C_ELM_LIST_FPL( t_14, l_methods, t_15 )
    t_11 = CALL_2ARGS( t_12, t_13, t_14 );
-   CHECK_FUNC_RESULT( t_11 );
-   CHECK_BOOL( t_11 );
+   CHECK_FUNC_RESULT( t_11 )
+   CHECK_BOOL( t_11 )
    t_10 = (Obj)(UInt)(t_11 != False);
    t_8 = t_10;
   }
@@ -1011,12 +1011,12 @@ static Obj  HdlrFunc8 (
   if ( t_7 ) {
    t_11 = GF_IS__SUBSET__FLAGS;
    C_ELM_POSOBJ_NLE( t_12, a_type5, 2 );
-   C_SUM_FIA( t_14, l_i, INTOBJ_INT(5) );
-   CHECK_INT_POS( t_14 );
-   C_ELM_LIST_FPL( t_13, l_methods, t_14 );
+   C_SUM_FIA( t_14, l_i, INTOBJ_INT(5) )
+   CHECK_INT_POS( t_14 )
+   C_ELM_LIST_FPL( t_13, l_methods, t_14 )
    t_10 = CALL_2ARGS( t_11, t_12, t_13 );
-   CHECK_FUNC_RESULT( t_10 );
-   CHECK_BOOL( t_10 );
+   CHECK_FUNC_RESULT( t_10 )
+   CHECK_BOOL( t_10 )
    t_9 = (Obj)(UInt)(t_10 != False);
    t_7 = t_9;
   }
@@ -1024,20 +1024,20 @@ static Obj  HdlrFunc8 (
   if ( t_6 ) {
    t_10 = GF_IS__SUBSET__FLAGS;
    C_ELM_POSOBJ_NLE( t_11, a_type6, 2 );
-   C_SUM_FIA( t_13, l_i, INTOBJ_INT(6) );
-   CHECK_INT_POS( t_13 );
-   C_ELM_LIST_FPL( t_12, l_methods, t_13 );
+   C_SUM_FIA( t_13, l_i, INTOBJ_INT(6) )
+   CHECK_INT_POS( t_13 )
+   C_ELM_LIST_FPL( t_12, l_methods, t_13 )
    t_9 = CALL_2ARGS( t_10, t_11, t_12 );
-   CHECK_FUNC_RESULT( t_9 );
-   CHECK_BOOL( t_9 );
+   CHECK_FUNC_RESULT( t_9 )
+   CHECK_BOOL( t_9 )
    t_8 = (Obj)(UInt)(t_9 != False);
    t_6 = t_8;
   }
   t_5 = t_6;
   if ( t_5 ) {
-   CHECK_INT_POS( l_i );
-   C_ELM_LIST_FPL( t_9, l_methods, l_i );
-   CHECK_FUNC( t_9 );
+   CHECK_INT_POS( l_i )
+   C_ELM_LIST_FPL( t_9, l_methods, l_i )
+   CHECK_FUNC( t_9 )
    C_ELM_POSOBJ_NLE( t_10, a_type1, 1 );
    C_ELM_POSOBJ_NLE( t_11, a_type2, 1 );
    C_ELM_POSOBJ_NLE( t_12, a_type3, 1 );
@@ -1045,17 +1045,17 @@ static Obj  HdlrFunc8 (
    C_ELM_POSOBJ_NLE( t_14, a_type5, 1 );
    C_ELM_POSOBJ_NLE( t_15, a_type6, 1 );
    t_8 = CALL_6ARGS( t_9, t_10, t_11, t_12, t_13, t_14, t_15 );
-   CHECK_FUNC_RESULT( t_8 );
-   CHECK_BOOL( t_8 );
+   CHECK_FUNC_RESULT( t_8 )
+   CHECK_BOOL( t_8 )
    t_7 = (Obj)(UInt)(t_8 != False);
    t_5 = t_7;
   }
   if ( t_5 ) {
    
    /* return methods[i + 7]; */
-   C_SUM_FIA( t_6, l_i, INTOBJ_INT(7) );
-   CHECK_INT_POS( t_6 );
-   C_ELM_LIST_FPL( t_5, l_methods, t_6 );
+   C_SUM_FIA( t_6, l_i, INTOBJ_INT(7) )
+   CHECK_INT_POS( t_6 )
+   C_ELM_LIST_FPL( t_5, l_methods, t_6 )
    RES_BRK_CURR_STAT();
    SWITCH_TO_OLD_FRAME(oldFrame);
    return t_5;
@@ -1068,7 +1068,7 @@ static Obj  HdlrFunc8 (
  
  /* return fail; */
  t_1 = GC_fail;
- CHECK_BOUND( t_1, "fail" );
+ CHECK_BOUND( t_1, "fail" )
  RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
@@ -1138,7 +1138,7 @@ static Obj  HdlrFunc10 (
  /* methods := METHODS_OPERATION( operation, 0 ); */
  t_2 = GF_METHODS__OPERATION;
  t_1 = CALL_2ARGS( t_2, a_operation, INTOBJ_INT(0) );
- CHECK_FUNC_RESULT( t_1 );
+ CHECK_FUNC_RESULT( t_1 )
  l_methods = t_1;
  
  /* j := 0; */
@@ -1147,24 +1147,24 @@ static Obj  HdlrFunc10 (
  /* for i in [ 1 .. LEN_LIST( methods ) / 4 ] do */
  t_4 = GF_LEN__LIST;
  t_3 = CALL_1ARGS( t_4, l_methods );
- CHECK_FUNC_RESULT( t_3 );
+ CHECK_FUNC_RESULT( t_3 )
  t_2 = QUO( t_3, INTOBJ_INT(4) );
- CHECK_INT_SMALL( t_2 );
+ CHECK_INT_SMALL( t_2 )
  for ( t_1 = INTOBJ_INT(1);
        ((Int)t_1) <= ((Int)t_2);
        t_1 = (Obj)(((UInt)t_1)+4) ) {
   l_i = t_1;
   
   /* if methods[4 * (i - 1) + 1](  ) then */
-  C_DIFF_INTOBJS( t_8, l_i, INTOBJ_INT(1) );
-  C_PROD_FIA( t_7, INTOBJ_INT(4), t_8 );
-  C_SUM_FIA( t_6, t_7, INTOBJ_INT(1) );
-  CHECK_INT_POS( t_6 );
-  C_ELM_LIST_FPL( t_5, l_methods, t_6 );
-  CHECK_FUNC( t_5 );
+  C_DIFF_INTOBJS( t_8, l_i, INTOBJ_INT(1) )
+  C_PROD_FIA( t_7, INTOBJ_INT(4), t_8 )
+  C_SUM_FIA( t_6, t_7, INTOBJ_INT(1) )
+  CHECK_INT_POS( t_6 )
+  C_ELM_LIST_FPL( t_5, l_methods, t_6 )
+  CHECK_FUNC( t_5 )
   t_4 = CALL_0ARGS( t_5 );
-  CHECK_FUNC_RESULT( t_4 );
-  CHECK_BOOL( t_4 );
+  CHECK_FUNC_RESULT( t_4 )
+  CHECK_BOOL( t_4 )
   t_3 = (Obj)(UInt)(t_4 != False);
   if ( t_3 ) {
    
@@ -1173,11 +1173,11 @@ static Obj  HdlrFunc10 (
    if ( t_3 ) {
     
     /* return methods[4 * (i - 1) + 2]; */
-    C_DIFF_INTOBJS( t_6, l_i, INTOBJ_INT(1) );
-    C_PROD_FIA( t_5, INTOBJ_INT(4), t_6 );
-    C_SUM_FIA( t_4, t_5, INTOBJ_INT(2) );
-    CHECK_INT_POS( t_4 );
-    C_ELM_LIST_FPL( t_3, l_methods, t_4 );
+    C_DIFF_INTOBJS( t_6, l_i, INTOBJ_INT(1) )
+    C_PROD_FIA( t_5, INTOBJ_INT(4), t_6 )
+    C_SUM_FIA( t_4, t_5, INTOBJ_INT(2) )
+    CHECK_INT_POS( t_4 )
+    C_ELM_LIST_FPL( t_3, l_methods, t_4 )
     RES_BRK_CURR_STAT();
     SWITCH_TO_OLD_FRAME(oldFrame);
     return t_3;
@@ -1188,7 +1188,7 @@ static Obj  HdlrFunc10 (
    else {
     
     /* j := j + 1; */
-    C_SUM_FIA( t_3, l_j, INTOBJ_INT(1) );
+    C_SUM_FIA( t_3, l_j, INTOBJ_INT(1) )
     l_j = t_3;
     
    }
@@ -1202,7 +1202,7 @@ static Obj  HdlrFunc10 (
  
  /* return fail; */
  t_1 = GC_fail;
- CHECK_BOUND( t_1, "fail" );
+ CHECK_BOUND( t_1, "fail" )
  RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
@@ -1245,7 +1245,7 @@ static Obj  HdlrFunc11 (
  /* methods := METHODS_OPERATION( operation, 1 ); */
  t_2 = GF_METHODS__OPERATION;
  t_1 = CALL_2ARGS( t_2, a_operation, INTOBJ_INT(1) );
- CHECK_FUNC_RESULT( t_1 );
+ CHECK_FUNC_RESULT( t_1 )
  l_methods = t_1;
  
  /* j := 0; */
@@ -1254,9 +1254,9 @@ static Obj  HdlrFunc11 (
  /* for i in [ 1 .. LEN_LIST( methods ) / 5 ] do */
  t_4 = GF_LEN__LIST;
  t_3 = CALL_1ARGS( t_4, l_methods );
- CHECK_FUNC_RESULT( t_3 );
+ CHECK_FUNC_RESULT( t_3 )
  t_2 = QUO( t_3, INTOBJ_INT(5) );
- CHECK_INT_SMALL( t_2 );
+ CHECK_INT_SMALL( t_2 )
  for ( t_1 = INTOBJ_INT(1);
        ((Int)t_1) <= ((Int)t_2);
        t_1 = (Obj)(((UInt)t_1)+4) ) {
@@ -1265,27 +1265,27 @@ static Obj  HdlrFunc11 (
   /* if IS_SUBSET_FLAGS( type1![2], methods[5 * (i - 1) + 2] ) and methods[5 * (i - 1) + 1]( type1![1] ) then */
   t_6 = GF_IS__SUBSET__FLAGS;
   C_ELM_POSOBJ_NLE( t_7, a_type1, 2 );
-  C_DIFF_INTOBJS( t_11, l_i, INTOBJ_INT(1) );
-  C_PROD_FIA( t_10, INTOBJ_INT(5), t_11 );
-  C_SUM_FIA( t_9, t_10, INTOBJ_INT(2) );
-  CHECK_INT_POS( t_9 );
-  C_ELM_LIST_FPL( t_8, l_methods, t_9 );
+  C_DIFF_INTOBJS( t_11, l_i, INTOBJ_INT(1) )
+  C_PROD_FIA( t_10, INTOBJ_INT(5), t_11 )
+  C_SUM_FIA( t_9, t_10, INTOBJ_INT(2) )
+  CHECK_INT_POS( t_9 )
+  C_ELM_LIST_FPL( t_8, l_methods, t_9 )
   t_5 = CALL_2ARGS( t_6, t_7, t_8 );
-  CHECK_FUNC_RESULT( t_5 );
-  CHECK_BOOL( t_5 );
+  CHECK_FUNC_RESULT( t_5 )
+  CHECK_BOOL( t_5 )
   t_4 = (Obj)(UInt)(t_5 != False);
   t_3 = t_4;
   if ( t_3 ) {
-   C_DIFF_INTOBJS( t_10, l_i, INTOBJ_INT(1) );
-   C_PROD_FIA( t_9, INTOBJ_INT(5), t_10 );
-   C_SUM_FIA( t_8, t_9, INTOBJ_INT(1) );
-   CHECK_INT_POS( t_8 );
-   C_ELM_LIST_FPL( t_7, l_methods, t_8 );
-   CHECK_FUNC( t_7 );
+   C_DIFF_INTOBJS( t_10, l_i, INTOBJ_INT(1) )
+   C_PROD_FIA( t_9, INTOBJ_INT(5), t_10 )
+   C_SUM_FIA( t_8, t_9, INTOBJ_INT(1) )
+   CHECK_INT_POS( t_8 )
+   C_ELM_LIST_FPL( t_7, l_methods, t_8 )
+   CHECK_FUNC( t_7 )
    C_ELM_POSOBJ_NLE( t_8, a_type1, 1 );
    t_6 = CALL_1ARGS( t_7, t_8 );
-   CHECK_FUNC_RESULT( t_6 );
-   CHECK_BOOL( t_6 );
+   CHECK_FUNC_RESULT( t_6 )
+   CHECK_BOOL( t_6 )
    t_5 = (Obj)(UInt)(t_6 != False);
    t_3 = t_5;
   }
@@ -1296,11 +1296,11 @@ static Obj  HdlrFunc11 (
    if ( t_3 ) {
     
     /* return methods[5 * (i - 1) + 3]; */
-    C_DIFF_INTOBJS( t_6, l_i, INTOBJ_INT(1) );
-    C_PROD_FIA( t_5, INTOBJ_INT(5), t_6 );
-    C_SUM_FIA( t_4, t_5, INTOBJ_INT(3) );
-    CHECK_INT_POS( t_4 );
-    C_ELM_LIST_FPL( t_3, l_methods, t_4 );
+    C_DIFF_INTOBJS( t_6, l_i, INTOBJ_INT(1) )
+    C_PROD_FIA( t_5, INTOBJ_INT(5), t_6 )
+    C_SUM_FIA( t_4, t_5, INTOBJ_INT(3) )
+    CHECK_INT_POS( t_4 )
+    C_ELM_LIST_FPL( t_3, l_methods, t_4 )
     RES_BRK_CURR_STAT();
     SWITCH_TO_OLD_FRAME(oldFrame);
     return t_3;
@@ -1311,7 +1311,7 @@ static Obj  HdlrFunc11 (
    else {
     
     /* j := j + 1; */
-    C_SUM_FIA( t_3, l_j, INTOBJ_INT(1) );
+    C_SUM_FIA( t_3, l_j, INTOBJ_INT(1) )
     l_j = t_3;
     
    }
@@ -1325,7 +1325,7 @@ static Obj  HdlrFunc11 (
  
  /* return fail; */
  t_1 = GC_fail;
- CHECK_BOUND( t_1, "fail" );
+ CHECK_BOUND( t_1, "fail" )
  RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
@@ -1371,7 +1371,7 @@ static Obj  HdlrFunc12 (
  /* methods := METHODS_OPERATION( operation, 2 ); */
  t_2 = GF_METHODS__OPERATION;
  t_1 = CALL_2ARGS( t_2, a_operation, INTOBJ_INT(2) );
- CHECK_FUNC_RESULT( t_1 );
+ CHECK_FUNC_RESULT( t_1 )
  l_methods = t_1;
  
  /* j := 0; */
@@ -1380,9 +1380,9 @@ static Obj  HdlrFunc12 (
  /* for i in [ 1 .. LEN_LIST( methods ) / 6 ] do */
  t_4 = GF_LEN__LIST;
  t_3 = CALL_1ARGS( t_4, l_methods );
- CHECK_FUNC_RESULT( t_3 );
+ CHECK_FUNC_RESULT( t_3 )
  t_2 = QUO( t_3, INTOBJ_INT(6) );
- CHECK_INT_SMALL( t_2 );
+ CHECK_INT_SMALL( t_2 )
  for ( t_1 = INTOBJ_INT(1);
        ((Int)t_1) <= ((Int)t_2);
        t_1 = (Obj)(((UInt)t_1)+4) ) {
@@ -1391,43 +1391,43 @@ static Obj  HdlrFunc12 (
   /* if IS_SUBSET_FLAGS( type1![2], methods[6 * (i - 1) + 2] ) and IS_SUBSET_FLAGS( type2![2], methods[6 * (i - 1) + 3] ) and methods[6 * (i - 1) + 1]( type1![1], type2![1] ) then */
   t_7 = GF_IS__SUBSET__FLAGS;
   C_ELM_POSOBJ_NLE( t_8, a_type1, 2 );
-  C_DIFF_INTOBJS( t_12, l_i, INTOBJ_INT(1) );
-  C_PROD_FIA( t_11, INTOBJ_INT(6), t_12 );
-  C_SUM_FIA( t_10, t_11, INTOBJ_INT(2) );
-  CHECK_INT_POS( t_10 );
-  C_ELM_LIST_FPL( t_9, l_methods, t_10 );
+  C_DIFF_INTOBJS( t_12, l_i, INTOBJ_INT(1) )
+  C_PROD_FIA( t_11, INTOBJ_INT(6), t_12 )
+  C_SUM_FIA( t_10, t_11, INTOBJ_INT(2) )
+  CHECK_INT_POS( t_10 )
+  C_ELM_LIST_FPL( t_9, l_methods, t_10 )
   t_6 = CALL_2ARGS( t_7, t_8, t_9 );
-  CHECK_FUNC_RESULT( t_6 );
-  CHECK_BOOL( t_6 );
+  CHECK_FUNC_RESULT( t_6 )
+  CHECK_BOOL( t_6 )
   t_5 = (Obj)(UInt)(t_6 != False);
   t_4 = t_5;
   if ( t_4 ) {
    t_8 = GF_IS__SUBSET__FLAGS;
    C_ELM_POSOBJ_NLE( t_9, a_type2, 2 );
-   C_DIFF_INTOBJS( t_13, l_i, INTOBJ_INT(1) );
-   C_PROD_FIA( t_12, INTOBJ_INT(6), t_13 );
-   C_SUM_FIA( t_11, t_12, INTOBJ_INT(3) );
-   CHECK_INT_POS( t_11 );
-   C_ELM_LIST_FPL( t_10, l_methods, t_11 );
+   C_DIFF_INTOBJS( t_13, l_i, INTOBJ_INT(1) )
+   C_PROD_FIA( t_12, INTOBJ_INT(6), t_13 )
+   C_SUM_FIA( t_11, t_12, INTOBJ_INT(3) )
+   CHECK_INT_POS( t_11 )
+   C_ELM_LIST_FPL( t_10, l_methods, t_11 )
    t_7 = CALL_2ARGS( t_8, t_9, t_10 );
-   CHECK_FUNC_RESULT( t_7 );
-   CHECK_BOOL( t_7 );
+   CHECK_FUNC_RESULT( t_7 )
+   CHECK_BOOL( t_7 )
    t_6 = (Obj)(UInt)(t_7 != False);
    t_4 = t_6;
   }
   t_3 = t_4;
   if ( t_3 ) {
-   C_DIFF_INTOBJS( t_10, l_i, INTOBJ_INT(1) );
-   C_PROD_FIA( t_9, INTOBJ_INT(6), t_10 );
-   C_SUM_FIA( t_8, t_9, INTOBJ_INT(1) );
-   CHECK_INT_POS( t_8 );
-   C_ELM_LIST_FPL( t_7, l_methods, t_8 );
-   CHECK_FUNC( t_7 );
+   C_DIFF_INTOBJS( t_10, l_i, INTOBJ_INT(1) )
+   C_PROD_FIA( t_9, INTOBJ_INT(6), t_10 )
+   C_SUM_FIA( t_8, t_9, INTOBJ_INT(1) )
+   CHECK_INT_POS( t_8 )
+   C_ELM_LIST_FPL( t_7, l_methods, t_8 )
+   CHECK_FUNC( t_7 )
    C_ELM_POSOBJ_NLE( t_8, a_type1, 1 );
    C_ELM_POSOBJ_NLE( t_9, a_type2, 1 );
    t_6 = CALL_2ARGS( t_7, t_8, t_9 );
-   CHECK_FUNC_RESULT( t_6 );
-   CHECK_BOOL( t_6 );
+   CHECK_FUNC_RESULT( t_6 )
+   CHECK_BOOL( t_6 )
    t_5 = (Obj)(UInt)(t_6 != False);
    t_3 = t_5;
   }
@@ -1438,11 +1438,11 @@ static Obj  HdlrFunc12 (
    if ( t_3 ) {
     
     /* return methods[6 * (i - 1) + 4]; */
-    C_DIFF_INTOBJS( t_6, l_i, INTOBJ_INT(1) );
-    C_PROD_FIA( t_5, INTOBJ_INT(6), t_6 );
-    C_SUM_FIA( t_4, t_5, INTOBJ_INT(4) );
-    CHECK_INT_POS( t_4 );
-    C_ELM_LIST_FPL( t_3, l_methods, t_4 );
+    C_DIFF_INTOBJS( t_6, l_i, INTOBJ_INT(1) )
+    C_PROD_FIA( t_5, INTOBJ_INT(6), t_6 )
+    C_SUM_FIA( t_4, t_5, INTOBJ_INT(4) )
+    CHECK_INT_POS( t_4 )
+    C_ELM_LIST_FPL( t_3, l_methods, t_4 )
     RES_BRK_CURR_STAT();
     SWITCH_TO_OLD_FRAME(oldFrame);
     return t_3;
@@ -1453,7 +1453,7 @@ static Obj  HdlrFunc12 (
    else {
     
     /* j := j + 1; */
-    C_SUM_FIA( t_3, l_j, INTOBJ_INT(1) );
+    C_SUM_FIA( t_3, l_j, INTOBJ_INT(1) )
     l_j = t_3;
     
    }
@@ -1467,7 +1467,7 @@ static Obj  HdlrFunc12 (
  
  /* return fail; */
  t_1 = GC_fail;
- CHECK_BOUND( t_1, "fail" );
+ CHECK_BOUND( t_1, "fail" )
  RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
@@ -1515,7 +1515,7 @@ static Obj  HdlrFunc13 (
  /* methods := METHODS_OPERATION( operation, 3 ); */
  t_2 = GF_METHODS__OPERATION;
  t_1 = CALL_2ARGS( t_2, a_operation, INTOBJ_INT(3) );
- CHECK_FUNC_RESULT( t_1 );
+ CHECK_FUNC_RESULT( t_1 )
  l_methods = t_1;
  
  /* j := 0; */
@@ -1524,9 +1524,9 @@ static Obj  HdlrFunc13 (
  /* for i in [ 1 .. LEN_LIST( methods ) / 7 ] do */
  t_4 = GF_LEN__LIST;
  t_3 = CALL_1ARGS( t_4, l_methods );
- CHECK_FUNC_RESULT( t_3 );
+ CHECK_FUNC_RESULT( t_3 )
  t_2 = QUO( t_3, INTOBJ_INT(7) );
- CHECK_INT_SMALL( t_2 );
+ CHECK_INT_SMALL( t_2 )
  for ( t_1 = INTOBJ_INT(1);
        ((Int)t_1) <= ((Int)t_2);
        t_1 = (Obj)(((UInt)t_1)+4) ) {
@@ -1535,27 +1535,27 @@ static Obj  HdlrFunc13 (
   /* if IS_SUBSET_FLAGS( type1![2], methods[7 * (i - 1) + 2] ) and IS_SUBSET_FLAGS( type2![2], methods[7 * (i - 1) + 3] ) and IS_SUBSET_FLAGS( type3![2], methods[7 * (i - 1) + 4] ) and methods[7 * (i - 1) + 1]( type1![1], type2![1], type3![1] ) then */
   t_8 = GF_IS__SUBSET__FLAGS;
   C_ELM_POSOBJ_NLE( t_9, a_type1, 2 );
-  C_DIFF_INTOBJS( t_13, l_i, INTOBJ_INT(1) );
-  C_PROD_FIA( t_12, INTOBJ_INT(7), t_13 );
-  C_SUM_FIA( t_11, t_12, INTOBJ_INT(2) );
-  CHECK_INT_POS( t_11 );
-  C_ELM_LIST_FPL( t_10, l_methods, t_11 );
+  C_DIFF_INTOBJS( t_13, l_i, INTOBJ_INT(1) )
+  C_PROD_FIA( t_12, INTOBJ_INT(7), t_13 )
+  C_SUM_FIA( t_11, t_12, INTOBJ_INT(2) )
+  CHECK_INT_POS( t_11 )
+  C_ELM_LIST_FPL( t_10, l_methods, t_11 )
   t_7 = CALL_2ARGS( t_8, t_9, t_10 );
-  CHECK_FUNC_RESULT( t_7 );
-  CHECK_BOOL( t_7 );
+  CHECK_FUNC_RESULT( t_7 )
+  CHECK_BOOL( t_7 )
   t_6 = (Obj)(UInt)(t_7 != False);
   t_5 = t_6;
   if ( t_5 ) {
    t_9 = GF_IS__SUBSET__FLAGS;
    C_ELM_POSOBJ_NLE( t_10, a_type2, 2 );
-   C_DIFF_INTOBJS( t_14, l_i, INTOBJ_INT(1) );
-   C_PROD_FIA( t_13, INTOBJ_INT(7), t_14 );
-   C_SUM_FIA( t_12, t_13, INTOBJ_INT(3) );
-   CHECK_INT_POS( t_12 );
-   C_ELM_LIST_FPL( t_11, l_methods, t_12 );
+   C_DIFF_INTOBJS( t_14, l_i, INTOBJ_INT(1) )
+   C_PROD_FIA( t_13, INTOBJ_INT(7), t_14 )
+   C_SUM_FIA( t_12, t_13, INTOBJ_INT(3) )
+   CHECK_INT_POS( t_12 )
+   C_ELM_LIST_FPL( t_11, l_methods, t_12 )
    t_8 = CALL_2ARGS( t_9, t_10, t_11 );
-   CHECK_FUNC_RESULT( t_8 );
-   CHECK_BOOL( t_8 );
+   CHECK_FUNC_RESULT( t_8 )
+   CHECK_BOOL( t_8 )
    t_7 = (Obj)(UInt)(t_8 != False);
    t_5 = t_7;
   }
@@ -1563,31 +1563,31 @@ static Obj  HdlrFunc13 (
   if ( t_4 ) {
    t_8 = GF_IS__SUBSET__FLAGS;
    C_ELM_POSOBJ_NLE( t_9, a_type3, 2 );
-   C_DIFF_INTOBJS( t_13, l_i, INTOBJ_INT(1) );
-   C_PROD_FIA( t_12, INTOBJ_INT(7), t_13 );
-   C_SUM_FIA( t_11, t_12, INTOBJ_INT(4) );
-   CHECK_INT_POS( t_11 );
-   C_ELM_LIST_FPL( t_10, l_methods, t_11 );
+   C_DIFF_INTOBJS( t_13, l_i, INTOBJ_INT(1) )
+   C_PROD_FIA( t_12, INTOBJ_INT(7), t_13 )
+   C_SUM_FIA( t_11, t_12, INTOBJ_INT(4) )
+   CHECK_INT_POS( t_11 )
+   C_ELM_LIST_FPL( t_10, l_methods, t_11 )
    t_7 = CALL_2ARGS( t_8, t_9, t_10 );
-   CHECK_FUNC_RESULT( t_7 );
-   CHECK_BOOL( t_7 );
+   CHECK_FUNC_RESULT( t_7 )
+   CHECK_BOOL( t_7 )
    t_6 = (Obj)(UInt)(t_7 != False);
    t_4 = t_6;
   }
   t_3 = t_4;
   if ( t_3 ) {
-   C_DIFF_INTOBJS( t_10, l_i, INTOBJ_INT(1) );
-   C_PROD_FIA( t_9, INTOBJ_INT(7), t_10 );
-   C_SUM_FIA( t_8, t_9, INTOBJ_INT(1) );
-   CHECK_INT_POS( t_8 );
-   C_ELM_LIST_FPL( t_7, l_methods, t_8 );
-   CHECK_FUNC( t_7 );
+   C_DIFF_INTOBJS( t_10, l_i, INTOBJ_INT(1) )
+   C_PROD_FIA( t_9, INTOBJ_INT(7), t_10 )
+   C_SUM_FIA( t_8, t_9, INTOBJ_INT(1) )
+   CHECK_INT_POS( t_8 )
+   C_ELM_LIST_FPL( t_7, l_methods, t_8 )
+   CHECK_FUNC( t_7 )
    C_ELM_POSOBJ_NLE( t_8, a_type1, 1 );
    C_ELM_POSOBJ_NLE( t_9, a_type2, 1 );
    C_ELM_POSOBJ_NLE( t_10, a_type3, 1 );
    t_6 = CALL_3ARGS( t_7, t_8, t_9, t_10 );
-   CHECK_FUNC_RESULT( t_6 );
-   CHECK_BOOL( t_6 );
+   CHECK_FUNC_RESULT( t_6 )
+   CHECK_BOOL( t_6 )
    t_5 = (Obj)(UInt)(t_6 != False);
    t_3 = t_5;
   }
@@ -1598,11 +1598,11 @@ static Obj  HdlrFunc13 (
    if ( t_3 ) {
     
     /* return methods[7 * (i - 1) + 5]; */
-    C_DIFF_INTOBJS( t_6, l_i, INTOBJ_INT(1) );
-    C_PROD_FIA( t_5, INTOBJ_INT(7), t_6 );
-    C_SUM_FIA( t_4, t_5, INTOBJ_INT(5) );
-    CHECK_INT_POS( t_4 );
-    C_ELM_LIST_FPL( t_3, l_methods, t_4 );
+    C_DIFF_INTOBJS( t_6, l_i, INTOBJ_INT(1) )
+    C_PROD_FIA( t_5, INTOBJ_INT(7), t_6 )
+    C_SUM_FIA( t_4, t_5, INTOBJ_INT(5) )
+    CHECK_INT_POS( t_4 )
+    C_ELM_LIST_FPL( t_3, l_methods, t_4 )
     RES_BRK_CURR_STAT();
     SWITCH_TO_OLD_FRAME(oldFrame);
     return t_3;
@@ -1613,7 +1613,7 @@ static Obj  HdlrFunc13 (
    else {
     
     /* j := j + 1; */
-    C_SUM_FIA( t_3, l_j, INTOBJ_INT(1) );
+    C_SUM_FIA( t_3, l_j, INTOBJ_INT(1) )
     l_j = t_3;
     
    }
@@ -1627,7 +1627,7 @@ static Obj  HdlrFunc13 (
  
  /* return fail; */
  t_1 = GC_fail;
- CHECK_BOUND( t_1, "fail" );
+ CHECK_BOUND( t_1, "fail" )
  RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
@@ -1677,7 +1677,7 @@ static Obj  HdlrFunc14 (
  /* methods := METHODS_OPERATION( operation, 4 ); */
  t_2 = GF_METHODS__OPERATION;
  t_1 = CALL_2ARGS( t_2, a_operation, INTOBJ_INT(4) );
- CHECK_FUNC_RESULT( t_1 );
+ CHECK_FUNC_RESULT( t_1 )
  l_methods = t_1;
  
  /* j := 0; */
@@ -1686,9 +1686,9 @@ static Obj  HdlrFunc14 (
  /* for i in [ 1 .. LEN_LIST( methods ) / 8 ] do */
  t_4 = GF_LEN__LIST;
  t_3 = CALL_1ARGS( t_4, l_methods );
- CHECK_FUNC_RESULT( t_3 );
+ CHECK_FUNC_RESULT( t_3 )
  t_2 = QUO( t_3, INTOBJ_INT(8) );
- CHECK_INT_SMALL( t_2 );
+ CHECK_INT_SMALL( t_2 )
  for ( t_1 = INTOBJ_INT(1);
        ((Int)t_1) <= ((Int)t_2);
        t_1 = (Obj)(((UInt)t_1)+4) ) {
@@ -1698,27 +1698,27 @@ static Obj  HdlrFunc14 (
 and methods[8 * (i - 1) + 1]( type1![1], type2![1], type3![1], type4![1] ) then */
   t_9 = GF_IS__SUBSET__FLAGS;
   C_ELM_POSOBJ_NLE( t_10, a_type1, 2 );
-  C_DIFF_INTOBJS( t_14, l_i, INTOBJ_INT(1) );
-  C_PROD_FIA( t_13, INTOBJ_INT(8), t_14 );
-  C_SUM_FIA( t_12, t_13, INTOBJ_INT(2) );
-  CHECK_INT_POS( t_12 );
-  C_ELM_LIST_FPL( t_11, l_methods, t_12 );
+  C_DIFF_INTOBJS( t_14, l_i, INTOBJ_INT(1) )
+  C_PROD_FIA( t_13, INTOBJ_INT(8), t_14 )
+  C_SUM_FIA( t_12, t_13, INTOBJ_INT(2) )
+  CHECK_INT_POS( t_12 )
+  C_ELM_LIST_FPL( t_11, l_methods, t_12 )
   t_8 = CALL_2ARGS( t_9, t_10, t_11 );
-  CHECK_FUNC_RESULT( t_8 );
-  CHECK_BOOL( t_8 );
+  CHECK_FUNC_RESULT( t_8 )
+  CHECK_BOOL( t_8 )
   t_7 = (Obj)(UInt)(t_8 != False);
   t_6 = t_7;
   if ( t_6 ) {
    t_10 = GF_IS__SUBSET__FLAGS;
    C_ELM_POSOBJ_NLE( t_11, a_type2, 2 );
-   C_DIFF_INTOBJS( t_15, l_i, INTOBJ_INT(1) );
-   C_PROD_FIA( t_14, INTOBJ_INT(8), t_15 );
-   C_SUM_FIA( t_13, t_14, INTOBJ_INT(3) );
-   CHECK_INT_POS( t_13 );
-   C_ELM_LIST_FPL( t_12, l_methods, t_13 );
+   C_DIFF_INTOBJS( t_15, l_i, INTOBJ_INT(1) )
+   C_PROD_FIA( t_14, INTOBJ_INT(8), t_15 )
+   C_SUM_FIA( t_13, t_14, INTOBJ_INT(3) )
+   CHECK_INT_POS( t_13 )
+   C_ELM_LIST_FPL( t_12, l_methods, t_13 )
    t_9 = CALL_2ARGS( t_10, t_11, t_12 );
-   CHECK_FUNC_RESULT( t_9 );
-   CHECK_BOOL( t_9 );
+   CHECK_FUNC_RESULT( t_9 )
+   CHECK_BOOL( t_9 )
    t_8 = (Obj)(UInt)(t_9 != False);
    t_6 = t_8;
   }
@@ -1726,14 +1726,14 @@ and methods[8 * (i - 1) + 1]( type1![1], type2![1], type3![1], type4![1] ) then 
   if ( t_5 ) {
    t_9 = GF_IS__SUBSET__FLAGS;
    C_ELM_POSOBJ_NLE( t_10, a_type3, 2 );
-   C_DIFF_INTOBJS( t_14, l_i, INTOBJ_INT(1) );
-   C_PROD_FIA( t_13, INTOBJ_INT(8), t_14 );
-   C_SUM_FIA( t_12, t_13, INTOBJ_INT(4) );
-   CHECK_INT_POS( t_12 );
-   C_ELM_LIST_FPL( t_11, l_methods, t_12 );
+   C_DIFF_INTOBJS( t_14, l_i, INTOBJ_INT(1) )
+   C_PROD_FIA( t_13, INTOBJ_INT(8), t_14 )
+   C_SUM_FIA( t_12, t_13, INTOBJ_INT(4) )
+   CHECK_INT_POS( t_12 )
+   C_ELM_LIST_FPL( t_11, l_methods, t_12 )
    t_8 = CALL_2ARGS( t_9, t_10, t_11 );
-   CHECK_FUNC_RESULT( t_8 );
-   CHECK_BOOL( t_8 );
+   CHECK_FUNC_RESULT( t_8 )
+   CHECK_BOOL( t_8 )
    t_7 = (Obj)(UInt)(t_8 != False);
    t_5 = t_7;
   }
@@ -1741,32 +1741,32 @@ and methods[8 * (i - 1) + 1]( type1![1], type2![1], type3![1], type4![1] ) then 
   if ( t_4 ) {
    t_8 = GF_IS__SUBSET__FLAGS;
    C_ELM_POSOBJ_NLE( t_9, a_type4, 2 );
-   C_DIFF_INTOBJS( t_13, l_i, INTOBJ_INT(1) );
-   C_PROD_FIA( t_12, INTOBJ_INT(8), t_13 );
-   C_SUM_FIA( t_11, t_12, INTOBJ_INT(5) );
-   CHECK_INT_POS( t_11 );
-   C_ELM_LIST_FPL( t_10, l_methods, t_11 );
+   C_DIFF_INTOBJS( t_13, l_i, INTOBJ_INT(1) )
+   C_PROD_FIA( t_12, INTOBJ_INT(8), t_13 )
+   C_SUM_FIA( t_11, t_12, INTOBJ_INT(5) )
+   CHECK_INT_POS( t_11 )
+   C_ELM_LIST_FPL( t_10, l_methods, t_11 )
    t_7 = CALL_2ARGS( t_8, t_9, t_10 );
-   CHECK_FUNC_RESULT( t_7 );
-   CHECK_BOOL( t_7 );
+   CHECK_FUNC_RESULT( t_7 )
+   CHECK_BOOL( t_7 )
    t_6 = (Obj)(UInt)(t_7 != False);
    t_4 = t_6;
   }
   t_3 = t_4;
   if ( t_3 ) {
-   C_DIFF_INTOBJS( t_10, l_i, INTOBJ_INT(1) );
-   C_PROD_FIA( t_9, INTOBJ_INT(8), t_10 );
-   C_SUM_FIA( t_8, t_9, INTOBJ_INT(1) );
-   CHECK_INT_POS( t_8 );
-   C_ELM_LIST_FPL( t_7, l_methods, t_8 );
-   CHECK_FUNC( t_7 );
+   C_DIFF_INTOBJS( t_10, l_i, INTOBJ_INT(1) )
+   C_PROD_FIA( t_9, INTOBJ_INT(8), t_10 )
+   C_SUM_FIA( t_8, t_9, INTOBJ_INT(1) )
+   CHECK_INT_POS( t_8 )
+   C_ELM_LIST_FPL( t_7, l_methods, t_8 )
+   CHECK_FUNC( t_7 )
    C_ELM_POSOBJ_NLE( t_8, a_type1, 1 );
    C_ELM_POSOBJ_NLE( t_9, a_type2, 1 );
    C_ELM_POSOBJ_NLE( t_10, a_type3, 1 );
    C_ELM_POSOBJ_NLE( t_11, a_type4, 1 );
    t_6 = CALL_4ARGS( t_7, t_8, t_9, t_10, t_11 );
-   CHECK_FUNC_RESULT( t_6 );
-   CHECK_BOOL( t_6 );
+   CHECK_FUNC_RESULT( t_6 )
+   CHECK_BOOL( t_6 )
    t_5 = (Obj)(UInt)(t_6 != False);
    t_3 = t_5;
   }
@@ -1777,11 +1777,11 @@ and methods[8 * (i - 1) + 1]( type1![1], type2![1], type3![1], type4![1] ) then 
    if ( t_3 ) {
     
     /* return methods[8 * (i - 1) + 6]; */
-    C_DIFF_INTOBJS( t_6, l_i, INTOBJ_INT(1) );
-    C_PROD_FIA( t_5, INTOBJ_INT(8), t_6 );
-    C_SUM_FIA( t_4, t_5, INTOBJ_INT(6) );
-    CHECK_INT_POS( t_4 );
-    C_ELM_LIST_FPL( t_3, l_methods, t_4 );
+    C_DIFF_INTOBJS( t_6, l_i, INTOBJ_INT(1) )
+    C_PROD_FIA( t_5, INTOBJ_INT(8), t_6 )
+    C_SUM_FIA( t_4, t_5, INTOBJ_INT(6) )
+    CHECK_INT_POS( t_4 )
+    C_ELM_LIST_FPL( t_3, l_methods, t_4 )
     RES_BRK_CURR_STAT();
     SWITCH_TO_OLD_FRAME(oldFrame);
     return t_3;
@@ -1792,7 +1792,7 @@ and methods[8 * (i - 1) + 1]( type1![1], type2![1], type3![1], type4![1] ) then 
    else {
     
     /* j := j + 1; */
-    C_SUM_FIA( t_3, l_j, INTOBJ_INT(1) );
+    C_SUM_FIA( t_3, l_j, INTOBJ_INT(1) )
     l_j = t_3;
     
    }
@@ -1806,7 +1806,7 @@ and methods[8 * (i - 1) + 1]( type1![1], type2![1], type3![1], type4![1] ) then 
  
  /* return fail; */
  t_1 = GC_fail;
- CHECK_BOUND( t_1, "fail" );
+ CHECK_BOUND( t_1, "fail" )
  RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
@@ -1850,7 +1850,7 @@ static Obj  HdlrFunc15 (
  Obj t_16 = 0;
  Bag oldFrame;
  OLD_BRK_CURR_STAT
- CHECK_NR_ARGS( 7, args );
+ CHECK_NR_ARGS( 7, args )
  a_operation = ELM_PLIST( args, 1 );
  a_k = ELM_PLIST( args, 2 );
  a_type1 = ELM_PLIST( args, 3 );
@@ -1867,7 +1867,7 @@ static Obj  HdlrFunc15 (
  /* methods := METHODS_OPERATION( operation, 5 ); */
  t_2 = GF_METHODS__OPERATION;
  t_1 = CALL_2ARGS( t_2, a_operation, INTOBJ_INT(5) );
- CHECK_FUNC_RESULT( t_1 );
+ CHECK_FUNC_RESULT( t_1 )
  l_methods = t_1;
  
  /* j := 0; */
@@ -1876,9 +1876,9 @@ static Obj  HdlrFunc15 (
  /* for i in [ 1 .. LEN_LIST( methods ) / 9 ] do */
  t_4 = GF_LEN__LIST;
  t_3 = CALL_1ARGS( t_4, l_methods );
- CHECK_FUNC_RESULT( t_3 );
+ CHECK_FUNC_RESULT( t_3 )
  t_2 = QUO( t_3, INTOBJ_INT(9) );
- CHECK_INT_SMALL( t_2 );
+ CHECK_INT_SMALL( t_2 )
  for ( t_1 = INTOBJ_INT(1);
        ((Int)t_1) <= ((Int)t_2);
        t_1 = (Obj)(((UInt)t_1)+4) ) {
@@ -1888,27 +1888,27 @@ static Obj  HdlrFunc15 (
   and IS_SUBSET_FLAGS( type5![2], methods[9 * (i - 1) + 6] ) and methods[9 * (i - 1) + 1]( type1![1], type2![1], type3![1], type4![1], type5![1] ) then */
   t_10 = GF_IS__SUBSET__FLAGS;
   C_ELM_POSOBJ_NLE( t_11, a_type1, 2 );
-  C_DIFF_INTOBJS( t_15, l_i, INTOBJ_INT(1) );
-  C_PROD_FIA( t_14, INTOBJ_INT(9), t_15 );
-  C_SUM_FIA( t_13, t_14, INTOBJ_INT(2) );
-  CHECK_INT_POS( t_13 );
-  C_ELM_LIST_FPL( t_12, l_methods, t_13 );
+  C_DIFF_INTOBJS( t_15, l_i, INTOBJ_INT(1) )
+  C_PROD_FIA( t_14, INTOBJ_INT(9), t_15 )
+  C_SUM_FIA( t_13, t_14, INTOBJ_INT(2) )
+  CHECK_INT_POS( t_13 )
+  C_ELM_LIST_FPL( t_12, l_methods, t_13 )
   t_9 = CALL_2ARGS( t_10, t_11, t_12 );
-  CHECK_FUNC_RESULT( t_9 );
-  CHECK_BOOL( t_9 );
+  CHECK_FUNC_RESULT( t_9 )
+  CHECK_BOOL( t_9 )
   t_8 = (Obj)(UInt)(t_9 != False);
   t_7 = t_8;
   if ( t_7 ) {
    t_11 = GF_IS__SUBSET__FLAGS;
    C_ELM_POSOBJ_NLE( t_12, a_type2, 2 );
-   C_DIFF_INTOBJS( t_16, l_i, INTOBJ_INT(1) );
-   C_PROD_FIA( t_15, INTOBJ_INT(9), t_16 );
-   C_SUM_FIA( t_14, t_15, INTOBJ_INT(3) );
-   CHECK_INT_POS( t_14 );
-   C_ELM_LIST_FPL( t_13, l_methods, t_14 );
+   C_DIFF_INTOBJS( t_16, l_i, INTOBJ_INT(1) )
+   C_PROD_FIA( t_15, INTOBJ_INT(9), t_16 )
+   C_SUM_FIA( t_14, t_15, INTOBJ_INT(3) )
+   CHECK_INT_POS( t_14 )
+   C_ELM_LIST_FPL( t_13, l_methods, t_14 )
    t_10 = CALL_2ARGS( t_11, t_12, t_13 );
-   CHECK_FUNC_RESULT( t_10 );
-   CHECK_BOOL( t_10 );
+   CHECK_FUNC_RESULT( t_10 )
+   CHECK_BOOL( t_10 )
    t_9 = (Obj)(UInt)(t_10 != False);
    t_7 = t_9;
   }
@@ -1916,14 +1916,14 @@ static Obj  HdlrFunc15 (
   if ( t_6 ) {
    t_10 = GF_IS__SUBSET__FLAGS;
    C_ELM_POSOBJ_NLE( t_11, a_type3, 2 );
-   C_DIFF_INTOBJS( t_15, l_i, INTOBJ_INT(1) );
-   C_PROD_FIA( t_14, INTOBJ_INT(9), t_15 );
-   C_SUM_FIA( t_13, t_14, INTOBJ_INT(4) );
-   CHECK_INT_POS( t_13 );
-   C_ELM_LIST_FPL( t_12, l_methods, t_13 );
+   C_DIFF_INTOBJS( t_15, l_i, INTOBJ_INT(1) )
+   C_PROD_FIA( t_14, INTOBJ_INT(9), t_15 )
+   C_SUM_FIA( t_13, t_14, INTOBJ_INT(4) )
+   CHECK_INT_POS( t_13 )
+   C_ELM_LIST_FPL( t_12, l_methods, t_13 )
    t_9 = CALL_2ARGS( t_10, t_11, t_12 );
-   CHECK_FUNC_RESULT( t_9 );
-   CHECK_BOOL( t_9 );
+   CHECK_FUNC_RESULT( t_9 )
+   CHECK_BOOL( t_9 )
    t_8 = (Obj)(UInt)(t_9 != False);
    t_6 = t_8;
   }
@@ -1931,14 +1931,14 @@ static Obj  HdlrFunc15 (
   if ( t_5 ) {
    t_9 = GF_IS__SUBSET__FLAGS;
    C_ELM_POSOBJ_NLE( t_10, a_type4, 2 );
-   C_DIFF_INTOBJS( t_14, l_i, INTOBJ_INT(1) );
-   C_PROD_FIA( t_13, INTOBJ_INT(9), t_14 );
-   C_SUM_FIA( t_12, t_13, INTOBJ_INT(5) );
-   CHECK_INT_POS( t_12 );
-   C_ELM_LIST_FPL( t_11, l_methods, t_12 );
+   C_DIFF_INTOBJS( t_14, l_i, INTOBJ_INT(1) )
+   C_PROD_FIA( t_13, INTOBJ_INT(9), t_14 )
+   C_SUM_FIA( t_12, t_13, INTOBJ_INT(5) )
+   CHECK_INT_POS( t_12 )
+   C_ELM_LIST_FPL( t_11, l_methods, t_12 )
    t_8 = CALL_2ARGS( t_9, t_10, t_11 );
-   CHECK_FUNC_RESULT( t_8 );
-   CHECK_BOOL( t_8 );
+   CHECK_FUNC_RESULT( t_8 )
+   CHECK_BOOL( t_8 )
    t_7 = (Obj)(UInt)(t_8 != False);
    t_5 = t_7;
   }
@@ -1946,33 +1946,33 @@ static Obj  HdlrFunc15 (
   if ( t_4 ) {
    t_8 = GF_IS__SUBSET__FLAGS;
    C_ELM_POSOBJ_NLE( t_9, a_type5, 2 );
-   C_DIFF_INTOBJS( t_13, l_i, INTOBJ_INT(1) );
-   C_PROD_FIA( t_12, INTOBJ_INT(9), t_13 );
-   C_SUM_FIA( t_11, t_12, INTOBJ_INT(6) );
-   CHECK_INT_POS( t_11 );
-   C_ELM_LIST_FPL( t_10, l_methods, t_11 );
+   C_DIFF_INTOBJS( t_13, l_i, INTOBJ_INT(1) )
+   C_PROD_FIA( t_12, INTOBJ_INT(9), t_13 )
+   C_SUM_FIA( t_11, t_12, INTOBJ_INT(6) )
+   CHECK_INT_POS( t_11 )
+   C_ELM_LIST_FPL( t_10, l_methods, t_11 )
    t_7 = CALL_2ARGS( t_8, t_9, t_10 );
-   CHECK_FUNC_RESULT( t_7 );
-   CHECK_BOOL( t_7 );
+   CHECK_FUNC_RESULT( t_7 )
+   CHECK_BOOL( t_7 )
    t_6 = (Obj)(UInt)(t_7 != False);
    t_4 = t_6;
   }
   t_3 = t_4;
   if ( t_3 ) {
-   C_DIFF_INTOBJS( t_10, l_i, INTOBJ_INT(1) );
-   C_PROD_FIA( t_9, INTOBJ_INT(9), t_10 );
-   C_SUM_FIA( t_8, t_9, INTOBJ_INT(1) );
-   CHECK_INT_POS( t_8 );
-   C_ELM_LIST_FPL( t_7, l_methods, t_8 );
-   CHECK_FUNC( t_7 );
+   C_DIFF_INTOBJS( t_10, l_i, INTOBJ_INT(1) )
+   C_PROD_FIA( t_9, INTOBJ_INT(9), t_10 )
+   C_SUM_FIA( t_8, t_9, INTOBJ_INT(1) )
+   CHECK_INT_POS( t_8 )
+   C_ELM_LIST_FPL( t_7, l_methods, t_8 )
+   CHECK_FUNC( t_7 )
    C_ELM_POSOBJ_NLE( t_8, a_type1, 1 );
    C_ELM_POSOBJ_NLE( t_9, a_type2, 1 );
    C_ELM_POSOBJ_NLE( t_10, a_type3, 1 );
    C_ELM_POSOBJ_NLE( t_11, a_type4, 1 );
    C_ELM_POSOBJ_NLE( t_12, a_type5, 1 );
    t_6 = CALL_5ARGS( t_7, t_8, t_9, t_10, t_11, t_12 );
-   CHECK_FUNC_RESULT( t_6 );
-   CHECK_BOOL( t_6 );
+   CHECK_FUNC_RESULT( t_6 )
+   CHECK_BOOL( t_6 )
    t_5 = (Obj)(UInt)(t_6 != False);
    t_3 = t_5;
   }
@@ -1983,11 +1983,11 @@ static Obj  HdlrFunc15 (
    if ( t_3 ) {
     
     /* return methods[9 * (i - 1) + 7]; */
-    C_DIFF_INTOBJS( t_6, l_i, INTOBJ_INT(1) );
-    C_PROD_FIA( t_5, INTOBJ_INT(9), t_6 );
-    C_SUM_FIA( t_4, t_5, INTOBJ_INT(7) );
-    CHECK_INT_POS( t_4 );
-    C_ELM_LIST_FPL( t_3, l_methods, t_4 );
+    C_DIFF_INTOBJS( t_6, l_i, INTOBJ_INT(1) )
+    C_PROD_FIA( t_5, INTOBJ_INT(9), t_6 )
+    C_SUM_FIA( t_4, t_5, INTOBJ_INT(7) )
+    CHECK_INT_POS( t_4 )
+    C_ELM_LIST_FPL( t_3, l_methods, t_4 )
     RES_BRK_CURR_STAT();
     SWITCH_TO_OLD_FRAME(oldFrame);
     return t_3;
@@ -1998,7 +1998,7 @@ static Obj  HdlrFunc15 (
    else {
     
     /* j := j + 1; */
-    C_SUM_FIA( t_3, l_j, INTOBJ_INT(1) );
+    C_SUM_FIA( t_3, l_j, INTOBJ_INT(1) )
     l_j = t_3;
     
    }
@@ -2012,7 +2012,7 @@ static Obj  HdlrFunc15 (
  
  /* return fail; */
  t_1 = GC_fail;
- CHECK_BOUND( t_1, "fail" );
+ CHECK_BOUND( t_1, "fail" )
  RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
@@ -2058,7 +2058,7 @@ static Obj  HdlrFunc16 (
  Obj t_17 = 0;
  Bag oldFrame;
  OLD_BRK_CURR_STAT
- CHECK_NR_ARGS( 8, args );
+ CHECK_NR_ARGS( 8, args )
  a_operation = ELM_PLIST( args, 1 );
  a_k = ELM_PLIST( args, 2 );
  a_type1 = ELM_PLIST( args, 3 );
@@ -2076,7 +2076,7 @@ static Obj  HdlrFunc16 (
  /* methods := METHODS_OPERATION( operation, 6 ); */
  t_2 = GF_METHODS__OPERATION;
  t_1 = CALL_2ARGS( t_2, a_operation, INTOBJ_INT(6) );
- CHECK_FUNC_RESULT( t_1 );
+ CHECK_FUNC_RESULT( t_1 )
  l_methods = t_1;
  
  /* j := 0; */
@@ -2085,9 +2085,9 @@ static Obj  HdlrFunc16 (
  /* for i in [ 1 .. LEN_LIST( methods ) / 10 ] do */
  t_4 = GF_LEN__LIST;
  t_3 = CALL_1ARGS( t_4, l_methods );
- CHECK_FUNC_RESULT( t_3 );
+ CHECK_FUNC_RESULT( t_3 )
  t_2 = QUO( t_3, INTOBJ_INT(10) );
- CHECK_INT_SMALL( t_2 );
+ CHECK_INT_SMALL( t_2 )
  for ( t_1 = INTOBJ_INT(1);
        ((Int)t_1) <= ((Int)t_2);
        t_1 = (Obj)(((UInt)t_1)+4) ) {
@@ -2097,27 +2097,27 @@ static Obj  HdlrFunc16 (
     and IS_SUBSET_FLAGS( type5![2], methods[10 * (i - 1) + 6] ) and IS_SUBSET_FLAGS( type6![2], methods[10 * (i - 1) + 7] ) and methods[10 * (i - 1) + 1]( type1![1], type2![1], type3![1], type4![1], type5![1], type6![1] ) then */
   t_11 = GF_IS__SUBSET__FLAGS;
   C_ELM_POSOBJ_NLE( t_12, a_type1, 2 );
-  C_DIFF_INTOBJS( t_16, l_i, INTOBJ_INT(1) );
-  C_PROD_FIA( t_15, INTOBJ_INT(10), t_16 );
-  C_SUM_FIA( t_14, t_15, INTOBJ_INT(2) );
-  CHECK_INT_POS( t_14 );
-  C_ELM_LIST_FPL( t_13, l_methods, t_14 );
+  C_DIFF_INTOBJS( t_16, l_i, INTOBJ_INT(1) )
+  C_PROD_FIA( t_15, INTOBJ_INT(10), t_16 )
+  C_SUM_FIA( t_14, t_15, INTOBJ_INT(2) )
+  CHECK_INT_POS( t_14 )
+  C_ELM_LIST_FPL( t_13, l_methods, t_14 )
   t_10 = CALL_2ARGS( t_11, t_12, t_13 );
-  CHECK_FUNC_RESULT( t_10 );
-  CHECK_BOOL( t_10 );
+  CHECK_FUNC_RESULT( t_10 )
+  CHECK_BOOL( t_10 )
   t_9 = (Obj)(UInt)(t_10 != False);
   t_8 = t_9;
   if ( t_8 ) {
    t_12 = GF_IS__SUBSET__FLAGS;
    C_ELM_POSOBJ_NLE( t_13, a_type2, 2 );
-   C_DIFF_INTOBJS( t_17, l_i, INTOBJ_INT(1) );
-   C_PROD_FIA( t_16, INTOBJ_INT(10), t_17 );
-   C_SUM_FIA( t_15, t_16, INTOBJ_INT(3) );
-   CHECK_INT_POS( t_15 );
-   C_ELM_LIST_FPL( t_14, l_methods, t_15 );
+   C_DIFF_INTOBJS( t_17, l_i, INTOBJ_INT(1) )
+   C_PROD_FIA( t_16, INTOBJ_INT(10), t_17 )
+   C_SUM_FIA( t_15, t_16, INTOBJ_INT(3) )
+   CHECK_INT_POS( t_15 )
+   C_ELM_LIST_FPL( t_14, l_methods, t_15 )
    t_11 = CALL_2ARGS( t_12, t_13, t_14 );
-   CHECK_FUNC_RESULT( t_11 );
-   CHECK_BOOL( t_11 );
+   CHECK_FUNC_RESULT( t_11 )
+   CHECK_BOOL( t_11 )
    t_10 = (Obj)(UInt)(t_11 != False);
    t_8 = t_10;
   }
@@ -2125,14 +2125,14 @@ static Obj  HdlrFunc16 (
   if ( t_7 ) {
    t_11 = GF_IS__SUBSET__FLAGS;
    C_ELM_POSOBJ_NLE( t_12, a_type3, 2 );
-   C_DIFF_INTOBJS( t_16, l_i, INTOBJ_INT(1) );
-   C_PROD_FIA( t_15, INTOBJ_INT(10), t_16 );
-   C_SUM_FIA( t_14, t_15, INTOBJ_INT(4) );
-   CHECK_INT_POS( t_14 );
-   C_ELM_LIST_FPL( t_13, l_methods, t_14 );
+   C_DIFF_INTOBJS( t_16, l_i, INTOBJ_INT(1) )
+   C_PROD_FIA( t_15, INTOBJ_INT(10), t_16 )
+   C_SUM_FIA( t_14, t_15, INTOBJ_INT(4) )
+   CHECK_INT_POS( t_14 )
+   C_ELM_LIST_FPL( t_13, l_methods, t_14 )
    t_10 = CALL_2ARGS( t_11, t_12, t_13 );
-   CHECK_FUNC_RESULT( t_10 );
-   CHECK_BOOL( t_10 );
+   CHECK_FUNC_RESULT( t_10 )
+   CHECK_BOOL( t_10 )
    t_9 = (Obj)(UInt)(t_10 != False);
    t_7 = t_9;
   }
@@ -2140,14 +2140,14 @@ static Obj  HdlrFunc16 (
   if ( t_6 ) {
    t_10 = GF_IS__SUBSET__FLAGS;
    C_ELM_POSOBJ_NLE( t_11, a_type4, 2 );
-   C_DIFF_INTOBJS( t_15, l_i, INTOBJ_INT(1) );
-   C_PROD_FIA( t_14, INTOBJ_INT(10), t_15 );
-   C_SUM_FIA( t_13, t_14, INTOBJ_INT(5) );
-   CHECK_INT_POS( t_13 );
-   C_ELM_LIST_FPL( t_12, l_methods, t_13 );
+   C_DIFF_INTOBJS( t_15, l_i, INTOBJ_INT(1) )
+   C_PROD_FIA( t_14, INTOBJ_INT(10), t_15 )
+   C_SUM_FIA( t_13, t_14, INTOBJ_INT(5) )
+   CHECK_INT_POS( t_13 )
+   C_ELM_LIST_FPL( t_12, l_methods, t_13 )
    t_9 = CALL_2ARGS( t_10, t_11, t_12 );
-   CHECK_FUNC_RESULT( t_9 );
-   CHECK_BOOL( t_9 );
+   CHECK_FUNC_RESULT( t_9 )
+   CHECK_BOOL( t_9 )
    t_8 = (Obj)(UInt)(t_9 != False);
    t_6 = t_8;
   }
@@ -2155,14 +2155,14 @@ static Obj  HdlrFunc16 (
   if ( t_5 ) {
    t_9 = GF_IS__SUBSET__FLAGS;
    C_ELM_POSOBJ_NLE( t_10, a_type5, 2 );
-   C_DIFF_INTOBJS( t_14, l_i, INTOBJ_INT(1) );
-   C_PROD_FIA( t_13, INTOBJ_INT(10), t_14 );
-   C_SUM_FIA( t_12, t_13, INTOBJ_INT(6) );
-   CHECK_INT_POS( t_12 );
-   C_ELM_LIST_FPL( t_11, l_methods, t_12 );
+   C_DIFF_INTOBJS( t_14, l_i, INTOBJ_INT(1) )
+   C_PROD_FIA( t_13, INTOBJ_INT(10), t_14 )
+   C_SUM_FIA( t_12, t_13, INTOBJ_INT(6) )
+   CHECK_INT_POS( t_12 )
+   C_ELM_LIST_FPL( t_11, l_methods, t_12 )
    t_8 = CALL_2ARGS( t_9, t_10, t_11 );
-   CHECK_FUNC_RESULT( t_8 );
-   CHECK_BOOL( t_8 );
+   CHECK_FUNC_RESULT( t_8 )
+   CHECK_BOOL( t_8 )
    t_7 = (Obj)(UInt)(t_8 != False);
    t_5 = t_7;
   }
@@ -2170,25 +2170,25 @@ static Obj  HdlrFunc16 (
   if ( t_4 ) {
    t_8 = GF_IS__SUBSET__FLAGS;
    C_ELM_POSOBJ_NLE( t_9, a_type6, 2 );
-   C_DIFF_INTOBJS( t_13, l_i, INTOBJ_INT(1) );
-   C_PROD_FIA( t_12, INTOBJ_INT(10), t_13 );
-   C_SUM_FIA( t_11, t_12, INTOBJ_INT(7) );
-   CHECK_INT_POS( t_11 );
-   C_ELM_LIST_FPL( t_10, l_methods, t_11 );
+   C_DIFF_INTOBJS( t_13, l_i, INTOBJ_INT(1) )
+   C_PROD_FIA( t_12, INTOBJ_INT(10), t_13 )
+   C_SUM_FIA( t_11, t_12, INTOBJ_INT(7) )
+   CHECK_INT_POS( t_11 )
+   C_ELM_LIST_FPL( t_10, l_methods, t_11 )
    t_7 = CALL_2ARGS( t_8, t_9, t_10 );
-   CHECK_FUNC_RESULT( t_7 );
-   CHECK_BOOL( t_7 );
+   CHECK_FUNC_RESULT( t_7 )
+   CHECK_BOOL( t_7 )
    t_6 = (Obj)(UInt)(t_7 != False);
    t_4 = t_6;
   }
   t_3 = t_4;
   if ( t_3 ) {
-   C_DIFF_INTOBJS( t_10, l_i, INTOBJ_INT(1) );
-   C_PROD_FIA( t_9, INTOBJ_INT(10), t_10 );
-   C_SUM_FIA( t_8, t_9, INTOBJ_INT(1) );
-   CHECK_INT_POS( t_8 );
-   C_ELM_LIST_FPL( t_7, l_methods, t_8 );
-   CHECK_FUNC( t_7 );
+   C_DIFF_INTOBJS( t_10, l_i, INTOBJ_INT(1) )
+   C_PROD_FIA( t_9, INTOBJ_INT(10), t_10 )
+   C_SUM_FIA( t_8, t_9, INTOBJ_INT(1) )
+   CHECK_INT_POS( t_8 )
+   C_ELM_LIST_FPL( t_7, l_methods, t_8 )
+   CHECK_FUNC( t_7 )
    C_ELM_POSOBJ_NLE( t_8, a_type1, 1 );
    C_ELM_POSOBJ_NLE( t_9, a_type2, 1 );
    C_ELM_POSOBJ_NLE( t_10, a_type3, 1 );
@@ -2196,8 +2196,8 @@ static Obj  HdlrFunc16 (
    C_ELM_POSOBJ_NLE( t_12, a_type5, 1 );
    C_ELM_POSOBJ_NLE( t_13, a_type6, 1 );
    t_6 = CALL_6ARGS( t_7, t_8, t_9, t_10, t_11, t_12, t_13 );
-   CHECK_FUNC_RESULT( t_6 );
-   CHECK_BOOL( t_6 );
+   CHECK_FUNC_RESULT( t_6 )
+   CHECK_BOOL( t_6 )
    t_5 = (Obj)(UInt)(t_6 != False);
    t_3 = t_5;
   }
@@ -2208,11 +2208,11 @@ static Obj  HdlrFunc16 (
    if ( t_3 ) {
     
     /* return methods[10 * (i - 1) + 8]; */
-    C_DIFF_INTOBJS( t_6, l_i, INTOBJ_INT(1) );
-    C_PROD_FIA( t_5, INTOBJ_INT(10), t_6 );
-    C_SUM_FIA( t_4, t_5, INTOBJ_INT(8) );
-    CHECK_INT_POS( t_4 );
-    C_ELM_LIST_FPL( t_3, l_methods, t_4 );
+    C_DIFF_INTOBJS( t_6, l_i, INTOBJ_INT(1) )
+    C_PROD_FIA( t_5, INTOBJ_INT(10), t_6 )
+    C_SUM_FIA( t_4, t_5, INTOBJ_INT(8) )
+    CHECK_INT_POS( t_4 )
+    C_ELM_LIST_FPL( t_3, l_methods, t_4 )
     RES_BRK_CURR_STAT();
     SWITCH_TO_OLD_FRAME(oldFrame);
     return t_3;
@@ -2223,7 +2223,7 @@ static Obj  HdlrFunc16 (
    else {
     
     /* j := j + 1; */
-    C_SUM_FIA( t_3, l_j, INTOBJ_INT(1) );
+    C_SUM_FIA( t_3, l_j, INTOBJ_INT(1) )
     l_j = t_3;
     
    }
@@ -2237,7 +2237,7 @@ static Obj  HdlrFunc16 (
  
  /* return fail; */
  t_1 = GC_fail;
- CHECK_BOUND( t_1, "fail" );
+ CHECK_BOUND( t_1, "fail" )
  RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
@@ -2313,27 +2313,27 @@ static Obj  HdlrFunc18 (
  /* type := TypeObj( obj ); */
  t_2 = GF_TypeObj;
  t_1 = CALL_1ARGS( t_2, a_obj );
- CHECK_FUNC_RESULT( t_1 );
+ CHECK_FUNC_RESULT( t_1 )
  l_type = t_1;
  
  /* fam := FamilyObj( obj ); */
  t_2 = GF_FamilyObj;
  t_1 = CALL_1ARGS( t_2, a_obj );
- CHECK_FUNC_RESULT( t_1 );
+ CHECK_FUNC_RESULT( t_1 )
  l_fam = t_1;
  
  /* methods := METHODS_OPERATION( attr, 1 ); */
  t_2 = GF_METHODS__OPERATION;
  t_1 = CALL_2ARGS( t_2, a_attr, INTOBJ_INT(1) );
- CHECK_FUNC_RESULT( t_1 );
+ CHECK_FUNC_RESULT( t_1 )
  l_methods = t_1;
  
  /* for i in [ 1 .. LEN_LIST( methods ) / 5 ] do */
  t_4 = GF_LEN__LIST;
  t_3 = CALL_1ARGS( t_4, l_methods );
- CHECK_FUNC_RESULT( t_3 );
+ CHECK_FUNC_RESULT( t_3 )
  t_2 = QUO( t_3, INTOBJ_INT(5) );
- CHECK_INT_SMALL( t_2 );
+ CHECK_INT_SMALL( t_2 )
  for ( t_1 = INTOBJ_INT(1);
        ((Int)t_1) <= ((Int)t_2);
        t_1 = (Obj)(((UInt)t_1)+4) ) {
@@ -2350,34 +2350,34 @@ static Obj  HdlrFunc18 (
   else if ( l_flag == True ) {
    t_5 = GF_IS__SUBSET__FLAGS;
    C_ELM_POSOBJ_NLE( t_6, l_type, 2 );
-   C_DIFF_INTOBJS( t_10, l_i, INTOBJ_INT(1) );
-   C_PROD_FIA( t_9, INTOBJ_INT(5), t_10 );
-   C_SUM_FIA( t_8, t_9, INTOBJ_INT(2) );
-   CHECK_INT_POS( t_8 );
-   C_ELM_LIST_FPL( t_7, l_methods, t_8 );
+   C_DIFF_INTOBJS( t_10, l_i, INTOBJ_INT(1) )
+   C_PROD_FIA( t_9, INTOBJ_INT(5), t_10 )
+   C_SUM_FIA( t_8, t_9, INTOBJ_INT(2) )
+   CHECK_INT_POS( t_8 )
+   C_ELM_LIST_FPL( t_7, l_methods, t_8 )
    t_4 = CALL_2ARGS( t_5, t_6, t_7 );
-   CHECK_FUNC_RESULT( t_4 );
-   CHECK_BOOL( t_4 );
+   CHECK_FUNC_RESULT( t_4 )
+   CHECK_BOOL( t_4 )
    t_3 = t_4;
   }
   else {
-   CHECK_FUNC( l_flag );
+   CHECK_FUNC( l_flag )
    t_6 = GF_IS__SUBSET__FLAGS;
    C_ELM_POSOBJ_NLE( t_7, l_type, 2 );
-   C_DIFF_INTOBJS( t_11, l_i, INTOBJ_INT(1) );
-   C_PROD_FIA( t_10, INTOBJ_INT(5), t_11 );
-   C_SUM_FIA( t_9, t_10, INTOBJ_INT(2) );
-   CHECK_INT_POS( t_9 );
-   C_ELM_LIST_FPL( t_8, l_methods, t_9 );
+   C_DIFF_INTOBJS( t_11, l_i, INTOBJ_INT(1) )
+   C_PROD_FIA( t_10, INTOBJ_INT(5), t_11 )
+   C_SUM_FIA( t_9, t_10, INTOBJ_INT(2) )
+   CHECK_INT_POS( t_9 )
+   C_ELM_LIST_FPL( t_8, l_methods, t_9 )
    t_5 = CALL_2ARGS( t_6, t_7, t_8 );
-   CHECK_FUNC_RESULT( t_5 );
-   CHECK_FUNC( t_5 );
+   CHECK_FUNC_RESULT( t_5 )
+   CHECK_FUNC( t_5 )
    t_3 = NewAndFilter( l_flag, t_5 );
   }
   l_flag = t_3;
   
   /* if flag then */
-  CHECK_BOOL( l_flag );
+  CHECK_BOOL( l_flag )
   t_3 = (Obj)(UInt)(l_flag != False);
   if ( t_3 ) {
    
@@ -2386,28 +2386,28 @@ static Obj  HdlrFunc18 (
     t_3 = l_flag;
    }
    else if ( l_flag == True ) {
-    C_DIFF_INTOBJS( t_8, l_i, INTOBJ_INT(1) );
-    C_PROD_FIA( t_7, INTOBJ_INT(5), t_8 );
-    C_SUM_FIA( t_6, t_7, INTOBJ_INT(1) );
-    CHECK_INT_POS( t_6 );
-    C_ELM_LIST_FPL( t_5, l_methods, t_6 );
-    CHECK_FUNC( t_5 );
+    C_DIFF_INTOBJS( t_8, l_i, INTOBJ_INT(1) )
+    C_PROD_FIA( t_7, INTOBJ_INT(5), t_8 )
+    C_SUM_FIA( t_6, t_7, INTOBJ_INT(1) )
+    CHECK_INT_POS( t_6 )
+    C_ELM_LIST_FPL( t_5, l_methods, t_6 )
+    CHECK_FUNC( t_5 )
     t_4 = CALL_1ARGS( t_5, l_fam );
-    CHECK_FUNC_RESULT( t_4 );
-    CHECK_BOOL( t_4 );
+    CHECK_FUNC_RESULT( t_4 )
+    CHECK_BOOL( t_4 )
     t_3 = t_4;
    }
    else {
-    CHECK_FUNC( l_flag );
-    C_DIFF_INTOBJS( t_9, l_i, INTOBJ_INT(1) );
-    C_PROD_FIA( t_8, INTOBJ_INT(5), t_9 );
-    C_SUM_FIA( t_7, t_8, INTOBJ_INT(1) );
-    CHECK_INT_POS( t_7 );
-    C_ELM_LIST_FPL( t_6, l_methods, t_7 );
-    CHECK_FUNC( t_6 );
+    CHECK_FUNC( l_flag )
+    C_DIFF_INTOBJS( t_9, l_i, INTOBJ_INT(1) )
+    C_PROD_FIA( t_8, INTOBJ_INT(5), t_9 )
+    C_SUM_FIA( t_7, t_8, INTOBJ_INT(1) )
+    CHECK_INT_POS( t_7 )
+    C_ELM_LIST_FPL( t_6, l_methods, t_7 )
+    CHECK_FUNC( t_6 )
     t_5 = CALL_1ARGS( t_6, l_fam );
-    CHECK_FUNC_RESULT( t_5 );
-    CHECK_FUNC( t_5 );
+    CHECK_FUNC_RESULT( t_5 )
+    CHECK_FUNC( t_5 )
     t_3 = NewAndFilter( l_flag, t_5 );
    }
    l_flag = t_3;
@@ -2416,31 +2416,31 @@ static Obj  HdlrFunc18 (
   /* fi */
   
   /* if flag then */
-  CHECK_BOOL( l_flag );
+  CHECK_BOOL( l_flag )
   t_3 = (Obj)(UInt)(l_flag != False);
   if ( t_3 ) {
    
    /* attr := methods[5 * (i - 1) + 3]; */
-   C_DIFF_INTOBJS( t_6, l_i, INTOBJ_INT(1) );
-   C_PROD_FIA( t_5, INTOBJ_INT(5), t_6 );
-   C_SUM_FIA( t_4, t_5, INTOBJ_INT(3) );
-   CHECK_INT_POS( t_4 );
-   C_ELM_LIST_FPL( t_3, l_methods, t_4 );
+   C_DIFF_INTOBJS( t_6, l_i, INTOBJ_INT(1) )
+   C_PROD_FIA( t_5, INTOBJ_INT(5), t_6 )
+   C_SUM_FIA( t_4, t_5, INTOBJ_INT(3) )
+   CHECK_INT_POS( t_4 )
+   C_ELM_LIST_FPL( t_3, l_methods, t_4 )
    a_attr = t_3;
    
    /* erg := attr( obj ); */
-   CHECK_FUNC( a_attr );
+   CHECK_FUNC( a_attr )
    t_3 = CALL_1ARGS( a_attr, a_obj );
-   CHECK_FUNC_RESULT( t_3 );
+   CHECK_FUNC_RESULT( t_3 )
    l_erg = t_3;
    
    /* if not IS_IDENTICAL_OBJ( erg, TRY_NEXT_METHOD ) then */
    t_6 = GF_IS__IDENTICAL__OBJ;
    t_7 = GC_TRY__NEXT__METHOD;
-   CHECK_BOUND( t_7, "TRY_NEXT_METHOD" );
+   CHECK_BOUND( t_7, "TRY_NEXT_METHOD" )
    t_5 = CALL_2ARGS( t_6, l_erg, t_7 );
-   CHECK_FUNC_RESULT( t_5 );
-   CHECK_BOOL( t_5 );
+   CHECK_FUNC_RESULT( t_5 )
+   CHECK_BOOL( t_5 )
    t_4 = (Obj)(UInt)(t_5 != False);
    t_3 = (Obj)(UInt)( ! ((Int)t_4) );
    if ( t_3 ) {
@@ -2501,39 +2501,39 @@ static Obj  HdlrFunc19 (
  /* methods := METHODS_OPERATION( operation, 0 ); */
  t_2 = GF_METHODS__OPERATION;
  t_1 = CALL_2ARGS( t_2, a_operation, INTOBJ_INT(0) );
- CHECK_FUNC_RESULT( t_1 );
+ CHECK_FUNC_RESULT( t_1 )
  l_methods = t_1;
  
  /* for i in [ 1 .. LEN_LIST( methods ) / 4 ] do */
  t_4 = GF_LEN__LIST;
  t_3 = CALL_1ARGS( t_4, l_methods );
- CHECK_FUNC_RESULT( t_3 );
+ CHECK_FUNC_RESULT( t_3 )
  t_2 = QUO( t_3, INTOBJ_INT(4) );
- CHECK_INT_SMALL( t_2 );
+ CHECK_INT_SMALL( t_2 )
  for ( t_1 = INTOBJ_INT(1);
        ((Int)t_1) <= ((Int)t_2);
        t_1 = (Obj)(((UInt)t_1)+4) ) {
   l_i = t_1;
   
   /* if methods[4 * (i - 1) + 1](  ) then */
-  C_DIFF_INTOBJS( t_8, l_i, INTOBJ_INT(1) );
-  C_PROD_FIA( t_7, INTOBJ_INT(4), t_8 );
-  C_SUM_FIA( t_6, t_7, INTOBJ_INT(1) );
-  CHECK_INT_POS( t_6 );
-  C_ELM_LIST_FPL( t_5, l_methods, t_6 );
-  CHECK_FUNC( t_5 );
+  C_DIFF_INTOBJS( t_8, l_i, INTOBJ_INT(1) )
+  C_PROD_FIA( t_7, INTOBJ_INT(4), t_8 )
+  C_SUM_FIA( t_6, t_7, INTOBJ_INT(1) )
+  CHECK_INT_POS( t_6 )
+  C_ELM_LIST_FPL( t_5, l_methods, t_6 )
+  CHECK_FUNC( t_5 )
   t_4 = CALL_0ARGS( t_5 );
-  CHECK_FUNC_RESULT( t_4 );
-  CHECK_BOOL( t_4 );
+  CHECK_FUNC_RESULT( t_4 )
+  CHECK_BOOL( t_4 )
   t_3 = (Obj)(UInt)(t_4 != False);
   if ( t_3 ) {
    
    /* return methods[4 * (i - 1) + 2]; */
-   C_DIFF_INTOBJS( t_6, l_i, INTOBJ_INT(1) );
-   C_PROD_FIA( t_5, INTOBJ_INT(4), t_6 );
-   C_SUM_FIA( t_4, t_5, INTOBJ_INT(2) );
-   CHECK_INT_POS( t_4 );
-   C_ELM_LIST_FPL( t_3, l_methods, t_4 );
+   C_DIFF_INTOBJS( t_6, l_i, INTOBJ_INT(1) )
+   C_PROD_FIA( t_5, INTOBJ_INT(4), t_6 )
+   C_SUM_FIA( t_4, t_5, INTOBJ_INT(2) )
+   CHECK_INT_POS( t_4 )
+   C_ELM_LIST_FPL( t_3, l_methods, t_4 )
    RES_BRK_CURR_STAT();
    SWITCH_TO_OLD_FRAME(oldFrame);
    return t_3;
@@ -2546,7 +2546,7 @@ static Obj  HdlrFunc19 (
  
  /* return fail; */
  t_1 = GC_fail;
- CHECK_BOUND( t_1, "fail" );
+ CHECK_BOUND( t_1, "fail" )
  RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
@@ -2586,15 +2586,15 @@ static Obj  HdlrFunc20 (
  /* methods := METHODS_OPERATION( operation, 1 ); */
  t_2 = GF_METHODS__OPERATION;
  t_1 = CALL_2ARGS( t_2, a_operation, INTOBJ_INT(1) );
- CHECK_FUNC_RESULT( t_1 );
+ CHECK_FUNC_RESULT( t_1 )
  l_methods = t_1;
  
  /* for i in [ 1 .. LEN_LIST( methods ) / 5 ] do */
  t_4 = GF_LEN__LIST;
  t_3 = CALL_1ARGS( t_4, l_methods );
- CHECK_FUNC_RESULT( t_3 );
+ CHECK_FUNC_RESULT( t_3 )
  t_2 = QUO( t_3, INTOBJ_INT(5) );
- CHECK_INT_SMALL( t_2 );
+ CHECK_INT_SMALL( t_2 )
  for ( t_1 = INTOBJ_INT(1);
        ((Int)t_1) <= ((Int)t_2);
        t_1 = (Obj)(((UInt)t_1)+4) ) {
@@ -2602,37 +2602,37 @@ static Obj  HdlrFunc20 (
   
   /* if IS_SUBSET_FLAGS( methods[5 * (i - 1) + 2], flags1 ) and methods[5 * (i - 1) + 1]( flags1 ) then */
   t_6 = GF_IS__SUBSET__FLAGS;
-  C_DIFF_INTOBJS( t_10, l_i, INTOBJ_INT(1) );
-  C_PROD_FIA( t_9, INTOBJ_INT(5), t_10 );
-  C_SUM_FIA( t_8, t_9, INTOBJ_INT(2) );
-  CHECK_INT_POS( t_8 );
-  C_ELM_LIST_FPL( t_7, l_methods, t_8 );
+  C_DIFF_INTOBJS( t_10, l_i, INTOBJ_INT(1) )
+  C_PROD_FIA( t_9, INTOBJ_INT(5), t_10 )
+  C_SUM_FIA( t_8, t_9, INTOBJ_INT(2) )
+  CHECK_INT_POS( t_8 )
+  C_ELM_LIST_FPL( t_7, l_methods, t_8 )
   t_5 = CALL_2ARGS( t_6, t_7, a_flags1 );
-  CHECK_FUNC_RESULT( t_5 );
-  CHECK_BOOL( t_5 );
+  CHECK_FUNC_RESULT( t_5 )
+  CHECK_BOOL( t_5 )
   t_4 = (Obj)(UInt)(t_5 != False);
   t_3 = t_4;
   if ( t_3 ) {
-   C_DIFF_INTOBJS( t_10, l_i, INTOBJ_INT(1) );
-   C_PROD_FIA( t_9, INTOBJ_INT(5), t_10 );
-   C_SUM_FIA( t_8, t_9, INTOBJ_INT(1) );
-   CHECK_INT_POS( t_8 );
-   C_ELM_LIST_FPL( t_7, l_methods, t_8 );
-   CHECK_FUNC( t_7 );
+   C_DIFF_INTOBJS( t_10, l_i, INTOBJ_INT(1) )
+   C_PROD_FIA( t_9, INTOBJ_INT(5), t_10 )
+   C_SUM_FIA( t_8, t_9, INTOBJ_INT(1) )
+   CHECK_INT_POS( t_8 )
+   C_ELM_LIST_FPL( t_7, l_methods, t_8 )
+   CHECK_FUNC( t_7 )
    t_6 = CALL_1ARGS( t_7, a_flags1 );
-   CHECK_FUNC_RESULT( t_6 );
-   CHECK_BOOL( t_6 );
+   CHECK_FUNC_RESULT( t_6 )
+   CHECK_BOOL( t_6 )
    t_5 = (Obj)(UInt)(t_6 != False);
    t_3 = t_5;
   }
   if ( t_3 ) {
    
    /* return methods[5 * (i - 1) + 3]; */
-   C_DIFF_INTOBJS( t_6, l_i, INTOBJ_INT(1) );
-   C_PROD_FIA( t_5, INTOBJ_INT(5), t_6 );
-   C_SUM_FIA( t_4, t_5, INTOBJ_INT(3) );
-   CHECK_INT_POS( t_4 );
-   C_ELM_LIST_FPL( t_3, l_methods, t_4 );
+   C_DIFF_INTOBJS( t_6, l_i, INTOBJ_INT(1) )
+   C_PROD_FIA( t_5, INTOBJ_INT(5), t_6 )
+   C_SUM_FIA( t_4, t_5, INTOBJ_INT(3) )
+   CHECK_INT_POS( t_4 )
+   C_ELM_LIST_FPL( t_3, l_methods, t_4 )
    RES_BRK_CURR_STAT();
    SWITCH_TO_OLD_FRAME(oldFrame);
    return t_3;
@@ -2645,7 +2645,7 @@ static Obj  HdlrFunc20 (
  
  /* return fail; */
  t_1 = GC_fail;
- CHECK_BOUND( t_1, "fail" );
+ CHECK_BOUND( t_1, "fail" )
  RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
@@ -2689,15 +2689,15 @@ static Obj  HdlrFunc21 (
  /* methods := METHODS_OPERATION( operation, 2 ); */
  t_2 = GF_METHODS__OPERATION;
  t_1 = CALL_2ARGS( t_2, a_operation, INTOBJ_INT(2) );
- CHECK_FUNC_RESULT( t_1 );
+ CHECK_FUNC_RESULT( t_1 )
  l_methods = t_1;
  
  /* for i in [ 1 .. LEN_LIST( methods ) / 6 ] do */
  t_4 = GF_LEN__LIST;
  t_3 = CALL_1ARGS( t_4, l_methods );
- CHECK_FUNC_RESULT( t_3 );
+ CHECK_FUNC_RESULT( t_3 )
  t_2 = QUO( t_3, INTOBJ_INT(6) );
- CHECK_INT_SMALL( t_2 );
+ CHECK_INT_SMALL( t_2 )
  for ( t_1 = INTOBJ_INT(1);
        ((Int)t_1) <= ((Int)t_2);
        t_1 = (Obj)(((UInt)t_1)+4) ) {
@@ -2705,53 +2705,53 @@ static Obj  HdlrFunc21 (
   
   /* if IS_SUBSET_FLAGS( methods[6 * (i - 1) + 2], flags1 ) and IS_SUBSET_FLAGS( type2![2], methods[6 * (i - 1) + 3] ) and methods[6 * (i - 1) + 1]( flags1, type2![1] ) then */
   t_7 = GF_IS__SUBSET__FLAGS;
-  C_DIFF_INTOBJS( t_11, l_i, INTOBJ_INT(1) );
-  C_PROD_FIA( t_10, INTOBJ_INT(6), t_11 );
-  C_SUM_FIA( t_9, t_10, INTOBJ_INT(2) );
-  CHECK_INT_POS( t_9 );
-  C_ELM_LIST_FPL( t_8, l_methods, t_9 );
+  C_DIFF_INTOBJS( t_11, l_i, INTOBJ_INT(1) )
+  C_PROD_FIA( t_10, INTOBJ_INT(6), t_11 )
+  C_SUM_FIA( t_9, t_10, INTOBJ_INT(2) )
+  CHECK_INT_POS( t_9 )
+  C_ELM_LIST_FPL( t_8, l_methods, t_9 )
   t_6 = CALL_2ARGS( t_7, t_8, a_flags1 );
-  CHECK_FUNC_RESULT( t_6 );
-  CHECK_BOOL( t_6 );
+  CHECK_FUNC_RESULT( t_6 )
+  CHECK_BOOL( t_6 )
   t_5 = (Obj)(UInt)(t_6 != False);
   t_4 = t_5;
   if ( t_4 ) {
    t_8 = GF_IS__SUBSET__FLAGS;
    C_ELM_POSOBJ_NLE( t_9, a_type2, 2 );
-   C_DIFF_INTOBJS( t_13, l_i, INTOBJ_INT(1) );
-   C_PROD_FIA( t_12, INTOBJ_INT(6), t_13 );
-   C_SUM_FIA( t_11, t_12, INTOBJ_INT(3) );
-   CHECK_INT_POS( t_11 );
-   C_ELM_LIST_FPL( t_10, l_methods, t_11 );
+   C_DIFF_INTOBJS( t_13, l_i, INTOBJ_INT(1) )
+   C_PROD_FIA( t_12, INTOBJ_INT(6), t_13 )
+   C_SUM_FIA( t_11, t_12, INTOBJ_INT(3) )
+   CHECK_INT_POS( t_11 )
+   C_ELM_LIST_FPL( t_10, l_methods, t_11 )
    t_7 = CALL_2ARGS( t_8, t_9, t_10 );
-   CHECK_FUNC_RESULT( t_7 );
-   CHECK_BOOL( t_7 );
+   CHECK_FUNC_RESULT( t_7 )
+   CHECK_BOOL( t_7 )
    t_6 = (Obj)(UInt)(t_7 != False);
    t_4 = t_6;
   }
   t_3 = t_4;
   if ( t_3 ) {
-   C_DIFF_INTOBJS( t_10, l_i, INTOBJ_INT(1) );
-   C_PROD_FIA( t_9, INTOBJ_INT(6), t_10 );
-   C_SUM_FIA( t_8, t_9, INTOBJ_INT(1) );
-   CHECK_INT_POS( t_8 );
-   C_ELM_LIST_FPL( t_7, l_methods, t_8 );
-   CHECK_FUNC( t_7 );
+   C_DIFF_INTOBJS( t_10, l_i, INTOBJ_INT(1) )
+   C_PROD_FIA( t_9, INTOBJ_INT(6), t_10 )
+   C_SUM_FIA( t_8, t_9, INTOBJ_INT(1) )
+   CHECK_INT_POS( t_8 )
+   C_ELM_LIST_FPL( t_7, l_methods, t_8 )
+   CHECK_FUNC( t_7 )
    C_ELM_POSOBJ_NLE( t_8, a_type2, 1 );
    t_6 = CALL_2ARGS( t_7, a_flags1, t_8 );
-   CHECK_FUNC_RESULT( t_6 );
-   CHECK_BOOL( t_6 );
+   CHECK_FUNC_RESULT( t_6 )
+   CHECK_BOOL( t_6 )
    t_5 = (Obj)(UInt)(t_6 != False);
    t_3 = t_5;
   }
   if ( t_3 ) {
    
    /* return methods[6 * (i - 1) + 4]; */
-   C_DIFF_INTOBJS( t_6, l_i, INTOBJ_INT(1) );
-   C_PROD_FIA( t_5, INTOBJ_INT(6), t_6 );
-   C_SUM_FIA( t_4, t_5, INTOBJ_INT(4) );
-   CHECK_INT_POS( t_4 );
-   C_ELM_LIST_FPL( t_3, l_methods, t_4 );
+   C_DIFF_INTOBJS( t_6, l_i, INTOBJ_INT(1) )
+   C_PROD_FIA( t_5, INTOBJ_INT(6), t_6 )
+   C_SUM_FIA( t_4, t_5, INTOBJ_INT(4) )
+   CHECK_INT_POS( t_4 )
+   C_ELM_LIST_FPL( t_3, l_methods, t_4 )
    RES_BRK_CURR_STAT();
    SWITCH_TO_OLD_FRAME(oldFrame);
    return t_3;
@@ -2764,7 +2764,7 @@ static Obj  HdlrFunc21 (
  
  /* return fail; */
  t_1 = GC_fail;
- CHECK_BOUND( t_1, "fail" );
+ CHECK_BOUND( t_1, "fail" )
  RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
@@ -2810,15 +2810,15 @@ static Obj  HdlrFunc22 (
  /* methods := METHODS_OPERATION( operation, 3 ); */
  t_2 = GF_METHODS__OPERATION;
  t_1 = CALL_2ARGS( t_2, a_operation, INTOBJ_INT(3) );
- CHECK_FUNC_RESULT( t_1 );
+ CHECK_FUNC_RESULT( t_1 )
  l_methods = t_1;
  
  /* for i in [ 1 .. LEN_LIST( methods ) / 7 ] do */
  t_4 = GF_LEN__LIST;
  t_3 = CALL_1ARGS( t_4, l_methods );
- CHECK_FUNC_RESULT( t_3 );
+ CHECK_FUNC_RESULT( t_3 )
  t_2 = QUO( t_3, INTOBJ_INT(7) );
- CHECK_INT_SMALL( t_2 );
+ CHECK_INT_SMALL( t_2 )
  for ( t_1 = INTOBJ_INT(1);
        ((Int)t_1) <= ((Int)t_2);
        t_1 = (Obj)(((UInt)t_1)+4) ) {
@@ -2826,27 +2826,27 @@ static Obj  HdlrFunc22 (
   
   /* if IS_SUBSET_FLAGS( methods[7 * (i - 1) + 2], flags1 ) and IS_SUBSET_FLAGS( type2![2], methods[7 * (i - 1) + 3] ) and IS_SUBSET_FLAGS( type3![2], methods[7 * (i - 1) + 4] ) and methods[7 * (i - 1) + 1]( flags1, type2![1], type3![1] ) then */
   t_8 = GF_IS__SUBSET__FLAGS;
-  C_DIFF_INTOBJS( t_12, l_i, INTOBJ_INT(1) );
-  C_PROD_FIA( t_11, INTOBJ_INT(7), t_12 );
-  C_SUM_FIA( t_10, t_11, INTOBJ_INT(2) );
-  CHECK_INT_POS( t_10 );
-  C_ELM_LIST_FPL( t_9, l_methods, t_10 );
+  C_DIFF_INTOBJS( t_12, l_i, INTOBJ_INT(1) )
+  C_PROD_FIA( t_11, INTOBJ_INT(7), t_12 )
+  C_SUM_FIA( t_10, t_11, INTOBJ_INT(2) )
+  CHECK_INT_POS( t_10 )
+  C_ELM_LIST_FPL( t_9, l_methods, t_10 )
   t_7 = CALL_2ARGS( t_8, t_9, a_flags1 );
-  CHECK_FUNC_RESULT( t_7 );
-  CHECK_BOOL( t_7 );
+  CHECK_FUNC_RESULT( t_7 )
+  CHECK_BOOL( t_7 )
   t_6 = (Obj)(UInt)(t_7 != False);
   t_5 = t_6;
   if ( t_5 ) {
    t_9 = GF_IS__SUBSET__FLAGS;
    C_ELM_POSOBJ_NLE( t_10, a_type2, 2 );
-   C_DIFF_INTOBJS( t_14, l_i, INTOBJ_INT(1) );
-   C_PROD_FIA( t_13, INTOBJ_INT(7), t_14 );
-   C_SUM_FIA( t_12, t_13, INTOBJ_INT(3) );
-   CHECK_INT_POS( t_12 );
-   C_ELM_LIST_FPL( t_11, l_methods, t_12 );
+   C_DIFF_INTOBJS( t_14, l_i, INTOBJ_INT(1) )
+   C_PROD_FIA( t_13, INTOBJ_INT(7), t_14 )
+   C_SUM_FIA( t_12, t_13, INTOBJ_INT(3) )
+   CHECK_INT_POS( t_12 )
+   C_ELM_LIST_FPL( t_11, l_methods, t_12 )
    t_8 = CALL_2ARGS( t_9, t_10, t_11 );
-   CHECK_FUNC_RESULT( t_8 );
-   CHECK_BOOL( t_8 );
+   CHECK_FUNC_RESULT( t_8 )
+   CHECK_BOOL( t_8 )
    t_7 = (Obj)(UInt)(t_8 != False);
    t_5 = t_7;
   }
@@ -2854,41 +2854,41 @@ static Obj  HdlrFunc22 (
   if ( t_4 ) {
    t_8 = GF_IS__SUBSET__FLAGS;
    C_ELM_POSOBJ_NLE( t_9, a_type3, 2 );
-   C_DIFF_INTOBJS( t_13, l_i, INTOBJ_INT(1) );
-   C_PROD_FIA( t_12, INTOBJ_INT(7), t_13 );
-   C_SUM_FIA( t_11, t_12, INTOBJ_INT(4) );
-   CHECK_INT_POS( t_11 );
-   C_ELM_LIST_FPL( t_10, l_methods, t_11 );
+   C_DIFF_INTOBJS( t_13, l_i, INTOBJ_INT(1) )
+   C_PROD_FIA( t_12, INTOBJ_INT(7), t_13 )
+   C_SUM_FIA( t_11, t_12, INTOBJ_INT(4) )
+   CHECK_INT_POS( t_11 )
+   C_ELM_LIST_FPL( t_10, l_methods, t_11 )
    t_7 = CALL_2ARGS( t_8, t_9, t_10 );
-   CHECK_FUNC_RESULT( t_7 );
-   CHECK_BOOL( t_7 );
+   CHECK_FUNC_RESULT( t_7 )
+   CHECK_BOOL( t_7 )
    t_6 = (Obj)(UInt)(t_7 != False);
    t_4 = t_6;
   }
   t_3 = t_4;
   if ( t_3 ) {
-   C_DIFF_INTOBJS( t_10, l_i, INTOBJ_INT(1) );
-   C_PROD_FIA( t_9, INTOBJ_INT(7), t_10 );
-   C_SUM_FIA( t_8, t_9, INTOBJ_INT(1) );
-   CHECK_INT_POS( t_8 );
-   C_ELM_LIST_FPL( t_7, l_methods, t_8 );
-   CHECK_FUNC( t_7 );
+   C_DIFF_INTOBJS( t_10, l_i, INTOBJ_INT(1) )
+   C_PROD_FIA( t_9, INTOBJ_INT(7), t_10 )
+   C_SUM_FIA( t_8, t_9, INTOBJ_INT(1) )
+   CHECK_INT_POS( t_8 )
+   C_ELM_LIST_FPL( t_7, l_methods, t_8 )
+   CHECK_FUNC( t_7 )
    C_ELM_POSOBJ_NLE( t_8, a_type2, 1 );
    C_ELM_POSOBJ_NLE( t_9, a_type3, 1 );
    t_6 = CALL_3ARGS( t_7, a_flags1, t_8, t_9 );
-   CHECK_FUNC_RESULT( t_6 );
-   CHECK_BOOL( t_6 );
+   CHECK_FUNC_RESULT( t_6 )
+   CHECK_BOOL( t_6 )
    t_5 = (Obj)(UInt)(t_6 != False);
    t_3 = t_5;
   }
   if ( t_3 ) {
    
    /* return methods[7 * (i - 1) + 5]; */
-   C_DIFF_INTOBJS( t_6, l_i, INTOBJ_INT(1) );
-   C_PROD_FIA( t_5, INTOBJ_INT(7), t_6 );
-   C_SUM_FIA( t_4, t_5, INTOBJ_INT(5) );
-   CHECK_INT_POS( t_4 );
-   C_ELM_LIST_FPL( t_3, l_methods, t_4 );
+   C_DIFF_INTOBJS( t_6, l_i, INTOBJ_INT(1) )
+   C_PROD_FIA( t_5, INTOBJ_INT(7), t_6 )
+   C_SUM_FIA( t_4, t_5, INTOBJ_INT(5) )
+   CHECK_INT_POS( t_4 )
+   C_ELM_LIST_FPL( t_3, l_methods, t_4 )
    RES_BRK_CURR_STAT();
    SWITCH_TO_OLD_FRAME(oldFrame);
    return t_3;
@@ -2901,7 +2901,7 @@ static Obj  HdlrFunc22 (
  
  /* return fail; */
  t_1 = GC_fail;
- CHECK_BOUND( t_1, "fail" );
+ CHECK_BOUND( t_1, "fail" )
  RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
@@ -2949,15 +2949,15 @@ static Obj  HdlrFunc23 (
  /* methods := METHODS_OPERATION( operation, 4 ); */
  t_2 = GF_METHODS__OPERATION;
  t_1 = CALL_2ARGS( t_2, a_operation, INTOBJ_INT(4) );
- CHECK_FUNC_RESULT( t_1 );
+ CHECK_FUNC_RESULT( t_1 )
  l_methods = t_1;
  
  /* for i in [ 1 .. LEN_LIST( methods ) / 8 ] do */
  t_4 = GF_LEN__LIST;
  t_3 = CALL_1ARGS( t_4, l_methods );
- CHECK_FUNC_RESULT( t_3 );
+ CHECK_FUNC_RESULT( t_3 )
  t_2 = QUO( t_3, INTOBJ_INT(8) );
- CHECK_INT_SMALL( t_2 );
+ CHECK_INT_SMALL( t_2 )
  for ( t_1 = INTOBJ_INT(1);
        ((Int)t_1) <= ((Int)t_2);
        t_1 = (Obj)(((UInt)t_1)+4) ) {
@@ -2966,27 +2966,27 @@ static Obj  HdlrFunc23 (
   /* if IS_SUBSET_FLAGS( methods[8 * (i - 1) + 2], flags1 ) and IS_SUBSET_FLAGS( type2![2], methods[8 * (i - 1) + 3] ) and IS_SUBSET_FLAGS( type3![2], methods[8 * (i - 1) + 4] ) and IS_SUBSET_FLAGS( type4![2], methods[8 * (i - 1) + 5] ) 
 and methods[8 * (i - 1) + 1]( flags1, type2![1], type3![1], type4![1] ) then */
   t_9 = GF_IS__SUBSET__FLAGS;
-  C_DIFF_INTOBJS( t_13, l_i, INTOBJ_INT(1) );
-  C_PROD_FIA( t_12, INTOBJ_INT(8), t_13 );
-  C_SUM_FIA( t_11, t_12, INTOBJ_INT(2) );
-  CHECK_INT_POS( t_11 );
-  C_ELM_LIST_FPL( t_10, l_methods, t_11 );
+  C_DIFF_INTOBJS( t_13, l_i, INTOBJ_INT(1) )
+  C_PROD_FIA( t_12, INTOBJ_INT(8), t_13 )
+  C_SUM_FIA( t_11, t_12, INTOBJ_INT(2) )
+  CHECK_INT_POS( t_11 )
+  C_ELM_LIST_FPL( t_10, l_methods, t_11 )
   t_8 = CALL_2ARGS( t_9, t_10, a_flags1 );
-  CHECK_FUNC_RESULT( t_8 );
-  CHECK_BOOL( t_8 );
+  CHECK_FUNC_RESULT( t_8 )
+  CHECK_BOOL( t_8 )
   t_7 = (Obj)(UInt)(t_8 != False);
   t_6 = t_7;
   if ( t_6 ) {
    t_10 = GF_IS__SUBSET__FLAGS;
    C_ELM_POSOBJ_NLE( t_11, a_type2, 2 );
-   C_DIFF_INTOBJS( t_15, l_i, INTOBJ_INT(1) );
-   C_PROD_FIA( t_14, INTOBJ_INT(8), t_15 );
-   C_SUM_FIA( t_13, t_14, INTOBJ_INT(3) );
-   CHECK_INT_POS( t_13 );
-   C_ELM_LIST_FPL( t_12, l_methods, t_13 );
+   C_DIFF_INTOBJS( t_15, l_i, INTOBJ_INT(1) )
+   C_PROD_FIA( t_14, INTOBJ_INT(8), t_15 )
+   C_SUM_FIA( t_13, t_14, INTOBJ_INT(3) )
+   CHECK_INT_POS( t_13 )
+   C_ELM_LIST_FPL( t_12, l_methods, t_13 )
    t_9 = CALL_2ARGS( t_10, t_11, t_12 );
-   CHECK_FUNC_RESULT( t_9 );
-   CHECK_BOOL( t_9 );
+   CHECK_FUNC_RESULT( t_9 )
+   CHECK_BOOL( t_9 )
    t_8 = (Obj)(UInt)(t_9 != False);
    t_6 = t_8;
   }
@@ -2994,14 +2994,14 @@ and methods[8 * (i - 1) + 1]( flags1, type2![1], type3![1], type4![1] ) then */
   if ( t_5 ) {
    t_9 = GF_IS__SUBSET__FLAGS;
    C_ELM_POSOBJ_NLE( t_10, a_type3, 2 );
-   C_DIFF_INTOBJS( t_14, l_i, INTOBJ_INT(1) );
-   C_PROD_FIA( t_13, INTOBJ_INT(8), t_14 );
-   C_SUM_FIA( t_12, t_13, INTOBJ_INT(4) );
-   CHECK_INT_POS( t_12 );
-   C_ELM_LIST_FPL( t_11, l_methods, t_12 );
+   C_DIFF_INTOBJS( t_14, l_i, INTOBJ_INT(1) )
+   C_PROD_FIA( t_13, INTOBJ_INT(8), t_14 )
+   C_SUM_FIA( t_12, t_13, INTOBJ_INT(4) )
+   CHECK_INT_POS( t_12 )
+   C_ELM_LIST_FPL( t_11, l_methods, t_12 )
    t_8 = CALL_2ARGS( t_9, t_10, t_11 );
-   CHECK_FUNC_RESULT( t_8 );
-   CHECK_BOOL( t_8 );
+   CHECK_FUNC_RESULT( t_8 )
+   CHECK_BOOL( t_8 )
    t_7 = (Obj)(UInt)(t_8 != False);
    t_5 = t_7;
   }
@@ -3009,42 +3009,42 @@ and methods[8 * (i - 1) + 1]( flags1, type2![1], type3![1], type4![1] ) then */
   if ( t_4 ) {
    t_8 = GF_IS__SUBSET__FLAGS;
    C_ELM_POSOBJ_NLE( t_9, a_type4, 2 );
-   C_DIFF_INTOBJS( t_13, l_i, INTOBJ_INT(1) );
-   C_PROD_FIA( t_12, INTOBJ_INT(8), t_13 );
-   C_SUM_FIA( t_11, t_12, INTOBJ_INT(5) );
-   CHECK_INT_POS( t_11 );
-   C_ELM_LIST_FPL( t_10, l_methods, t_11 );
+   C_DIFF_INTOBJS( t_13, l_i, INTOBJ_INT(1) )
+   C_PROD_FIA( t_12, INTOBJ_INT(8), t_13 )
+   C_SUM_FIA( t_11, t_12, INTOBJ_INT(5) )
+   CHECK_INT_POS( t_11 )
+   C_ELM_LIST_FPL( t_10, l_methods, t_11 )
    t_7 = CALL_2ARGS( t_8, t_9, t_10 );
-   CHECK_FUNC_RESULT( t_7 );
-   CHECK_BOOL( t_7 );
+   CHECK_FUNC_RESULT( t_7 )
+   CHECK_BOOL( t_7 )
    t_6 = (Obj)(UInt)(t_7 != False);
    t_4 = t_6;
   }
   t_3 = t_4;
   if ( t_3 ) {
-   C_DIFF_INTOBJS( t_10, l_i, INTOBJ_INT(1) );
-   C_PROD_FIA( t_9, INTOBJ_INT(8), t_10 );
-   C_SUM_FIA( t_8, t_9, INTOBJ_INT(1) );
-   CHECK_INT_POS( t_8 );
-   C_ELM_LIST_FPL( t_7, l_methods, t_8 );
-   CHECK_FUNC( t_7 );
+   C_DIFF_INTOBJS( t_10, l_i, INTOBJ_INT(1) )
+   C_PROD_FIA( t_9, INTOBJ_INT(8), t_10 )
+   C_SUM_FIA( t_8, t_9, INTOBJ_INT(1) )
+   CHECK_INT_POS( t_8 )
+   C_ELM_LIST_FPL( t_7, l_methods, t_8 )
+   CHECK_FUNC( t_7 )
    C_ELM_POSOBJ_NLE( t_8, a_type2, 1 );
    C_ELM_POSOBJ_NLE( t_9, a_type3, 1 );
    C_ELM_POSOBJ_NLE( t_10, a_type4, 1 );
    t_6 = CALL_4ARGS( t_7, a_flags1, t_8, t_9, t_10 );
-   CHECK_FUNC_RESULT( t_6 );
-   CHECK_BOOL( t_6 );
+   CHECK_FUNC_RESULT( t_6 )
+   CHECK_BOOL( t_6 )
    t_5 = (Obj)(UInt)(t_6 != False);
    t_3 = t_5;
   }
   if ( t_3 ) {
    
    /* return methods[8 * (i - 1) + 6]; */
-   C_DIFF_INTOBJS( t_6, l_i, INTOBJ_INT(1) );
-   C_PROD_FIA( t_5, INTOBJ_INT(8), t_6 );
-   C_SUM_FIA( t_4, t_5, INTOBJ_INT(6) );
-   CHECK_INT_POS( t_4 );
-   C_ELM_LIST_FPL( t_3, l_methods, t_4 );
+   C_DIFF_INTOBJS( t_6, l_i, INTOBJ_INT(1) )
+   C_PROD_FIA( t_5, INTOBJ_INT(8), t_6 )
+   C_SUM_FIA( t_4, t_5, INTOBJ_INT(6) )
+   CHECK_INT_POS( t_4 )
+   C_ELM_LIST_FPL( t_3, l_methods, t_4 )
    RES_BRK_CURR_STAT();
    SWITCH_TO_OLD_FRAME(oldFrame);
    return t_3;
@@ -3057,7 +3057,7 @@ and methods[8 * (i - 1) + 1]( flags1, type2![1], type3![1], type4![1] ) then */
  
  /* return fail; */
  t_1 = GC_fail;
- CHECK_BOUND( t_1, "fail" );
+ CHECK_BOUND( t_1, "fail" )
  RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
@@ -3107,15 +3107,15 @@ static Obj  HdlrFunc24 (
  /* methods := METHODS_OPERATION( operation, 5 ); */
  t_2 = GF_METHODS__OPERATION;
  t_1 = CALL_2ARGS( t_2, a_operation, INTOBJ_INT(5) );
- CHECK_FUNC_RESULT( t_1 );
+ CHECK_FUNC_RESULT( t_1 )
  l_methods = t_1;
  
  /* for i in [ 1 .. LEN_LIST( methods ) / 9 ] do */
  t_4 = GF_LEN__LIST;
  t_3 = CALL_1ARGS( t_4, l_methods );
- CHECK_FUNC_RESULT( t_3 );
+ CHECK_FUNC_RESULT( t_3 )
  t_2 = QUO( t_3, INTOBJ_INT(9) );
- CHECK_INT_SMALL( t_2 );
+ CHECK_INT_SMALL( t_2 )
  for ( t_1 = INTOBJ_INT(1);
        ((Int)t_1) <= ((Int)t_2);
        t_1 = (Obj)(((UInt)t_1)+4) ) {
@@ -3124,27 +3124,27 @@ static Obj  HdlrFunc24 (
   /* if IS_SUBSET_FLAGS( methods[9 * (i - 1) + 2], flags1 ) and IS_SUBSET_FLAGS( type2![2], methods[9 * (i - 1) + 3] ) and IS_SUBSET_FLAGS( type3![2], methods[9 * (i - 1) + 4] ) and IS_SUBSET_FLAGS( type4![2], methods[9 * (i - 1) + 5] ) 
   and IS_SUBSET_FLAGS( type5![2], methods[9 * (i - 1) + 6] ) and methods[9 * (i - 1) + 1]( flags1, type2![1], type3![1], type4![1], type5![1] ) then */
   t_10 = GF_IS__SUBSET__FLAGS;
-  C_DIFF_INTOBJS( t_14, l_i, INTOBJ_INT(1) );
-  C_PROD_FIA( t_13, INTOBJ_INT(9), t_14 );
-  C_SUM_FIA( t_12, t_13, INTOBJ_INT(2) );
-  CHECK_INT_POS( t_12 );
-  C_ELM_LIST_FPL( t_11, l_methods, t_12 );
+  C_DIFF_INTOBJS( t_14, l_i, INTOBJ_INT(1) )
+  C_PROD_FIA( t_13, INTOBJ_INT(9), t_14 )
+  C_SUM_FIA( t_12, t_13, INTOBJ_INT(2) )
+  CHECK_INT_POS( t_12 )
+  C_ELM_LIST_FPL( t_11, l_methods, t_12 )
   t_9 = CALL_2ARGS( t_10, t_11, a_flags1 );
-  CHECK_FUNC_RESULT( t_9 );
-  CHECK_BOOL( t_9 );
+  CHECK_FUNC_RESULT( t_9 )
+  CHECK_BOOL( t_9 )
   t_8 = (Obj)(UInt)(t_9 != False);
   t_7 = t_8;
   if ( t_7 ) {
    t_11 = GF_IS__SUBSET__FLAGS;
    C_ELM_POSOBJ_NLE( t_12, a_type2, 2 );
-   C_DIFF_INTOBJS( t_16, l_i, INTOBJ_INT(1) );
-   C_PROD_FIA( t_15, INTOBJ_INT(9), t_16 );
-   C_SUM_FIA( t_14, t_15, INTOBJ_INT(3) );
-   CHECK_INT_POS( t_14 );
-   C_ELM_LIST_FPL( t_13, l_methods, t_14 );
+   C_DIFF_INTOBJS( t_16, l_i, INTOBJ_INT(1) )
+   C_PROD_FIA( t_15, INTOBJ_INT(9), t_16 )
+   C_SUM_FIA( t_14, t_15, INTOBJ_INT(3) )
+   CHECK_INT_POS( t_14 )
+   C_ELM_LIST_FPL( t_13, l_methods, t_14 )
    t_10 = CALL_2ARGS( t_11, t_12, t_13 );
-   CHECK_FUNC_RESULT( t_10 );
-   CHECK_BOOL( t_10 );
+   CHECK_FUNC_RESULT( t_10 )
+   CHECK_BOOL( t_10 )
    t_9 = (Obj)(UInt)(t_10 != False);
    t_7 = t_9;
   }
@@ -3152,14 +3152,14 @@ static Obj  HdlrFunc24 (
   if ( t_6 ) {
    t_10 = GF_IS__SUBSET__FLAGS;
    C_ELM_POSOBJ_NLE( t_11, a_type3, 2 );
-   C_DIFF_INTOBJS( t_15, l_i, INTOBJ_INT(1) );
-   C_PROD_FIA( t_14, INTOBJ_INT(9), t_15 );
-   C_SUM_FIA( t_13, t_14, INTOBJ_INT(4) );
-   CHECK_INT_POS( t_13 );
-   C_ELM_LIST_FPL( t_12, l_methods, t_13 );
+   C_DIFF_INTOBJS( t_15, l_i, INTOBJ_INT(1) )
+   C_PROD_FIA( t_14, INTOBJ_INT(9), t_15 )
+   C_SUM_FIA( t_13, t_14, INTOBJ_INT(4) )
+   CHECK_INT_POS( t_13 )
+   C_ELM_LIST_FPL( t_12, l_methods, t_13 )
    t_9 = CALL_2ARGS( t_10, t_11, t_12 );
-   CHECK_FUNC_RESULT( t_9 );
-   CHECK_BOOL( t_9 );
+   CHECK_FUNC_RESULT( t_9 )
+   CHECK_BOOL( t_9 )
    t_8 = (Obj)(UInt)(t_9 != False);
    t_6 = t_8;
   }
@@ -3167,14 +3167,14 @@ static Obj  HdlrFunc24 (
   if ( t_5 ) {
    t_9 = GF_IS__SUBSET__FLAGS;
    C_ELM_POSOBJ_NLE( t_10, a_type4, 2 );
-   C_DIFF_INTOBJS( t_14, l_i, INTOBJ_INT(1) );
-   C_PROD_FIA( t_13, INTOBJ_INT(9), t_14 );
-   C_SUM_FIA( t_12, t_13, INTOBJ_INT(5) );
-   CHECK_INT_POS( t_12 );
-   C_ELM_LIST_FPL( t_11, l_methods, t_12 );
+   C_DIFF_INTOBJS( t_14, l_i, INTOBJ_INT(1) )
+   C_PROD_FIA( t_13, INTOBJ_INT(9), t_14 )
+   C_SUM_FIA( t_12, t_13, INTOBJ_INT(5) )
+   CHECK_INT_POS( t_12 )
+   C_ELM_LIST_FPL( t_11, l_methods, t_12 )
    t_8 = CALL_2ARGS( t_9, t_10, t_11 );
-   CHECK_FUNC_RESULT( t_8 );
-   CHECK_BOOL( t_8 );
+   CHECK_FUNC_RESULT( t_8 )
+   CHECK_BOOL( t_8 )
    t_7 = (Obj)(UInt)(t_8 != False);
    t_5 = t_7;
   }
@@ -3182,43 +3182,43 @@ static Obj  HdlrFunc24 (
   if ( t_4 ) {
    t_8 = GF_IS__SUBSET__FLAGS;
    C_ELM_POSOBJ_NLE( t_9, a_type5, 2 );
-   C_DIFF_INTOBJS( t_13, l_i, INTOBJ_INT(1) );
-   C_PROD_FIA( t_12, INTOBJ_INT(9), t_13 );
-   C_SUM_FIA( t_11, t_12, INTOBJ_INT(6) );
-   CHECK_INT_POS( t_11 );
-   C_ELM_LIST_FPL( t_10, l_methods, t_11 );
+   C_DIFF_INTOBJS( t_13, l_i, INTOBJ_INT(1) )
+   C_PROD_FIA( t_12, INTOBJ_INT(9), t_13 )
+   C_SUM_FIA( t_11, t_12, INTOBJ_INT(6) )
+   CHECK_INT_POS( t_11 )
+   C_ELM_LIST_FPL( t_10, l_methods, t_11 )
    t_7 = CALL_2ARGS( t_8, t_9, t_10 );
-   CHECK_FUNC_RESULT( t_7 );
-   CHECK_BOOL( t_7 );
+   CHECK_FUNC_RESULT( t_7 )
+   CHECK_BOOL( t_7 )
    t_6 = (Obj)(UInt)(t_7 != False);
    t_4 = t_6;
   }
   t_3 = t_4;
   if ( t_3 ) {
-   C_DIFF_INTOBJS( t_10, l_i, INTOBJ_INT(1) );
-   C_PROD_FIA( t_9, INTOBJ_INT(9), t_10 );
-   C_SUM_FIA( t_8, t_9, INTOBJ_INT(1) );
-   CHECK_INT_POS( t_8 );
-   C_ELM_LIST_FPL( t_7, l_methods, t_8 );
-   CHECK_FUNC( t_7 );
+   C_DIFF_INTOBJS( t_10, l_i, INTOBJ_INT(1) )
+   C_PROD_FIA( t_9, INTOBJ_INT(9), t_10 )
+   C_SUM_FIA( t_8, t_9, INTOBJ_INT(1) )
+   CHECK_INT_POS( t_8 )
+   C_ELM_LIST_FPL( t_7, l_methods, t_8 )
+   CHECK_FUNC( t_7 )
    C_ELM_POSOBJ_NLE( t_8, a_type2, 1 );
    C_ELM_POSOBJ_NLE( t_9, a_type3, 1 );
    C_ELM_POSOBJ_NLE( t_10, a_type4, 1 );
    C_ELM_POSOBJ_NLE( t_11, a_type5, 1 );
    t_6 = CALL_5ARGS( t_7, a_flags1, t_8, t_9, t_10, t_11 );
-   CHECK_FUNC_RESULT( t_6 );
-   CHECK_BOOL( t_6 );
+   CHECK_FUNC_RESULT( t_6 )
+   CHECK_BOOL( t_6 )
    t_5 = (Obj)(UInt)(t_6 != False);
    t_3 = t_5;
   }
   if ( t_3 ) {
    
    /* return methods[9 * (i - 1) + 7]; */
-   C_DIFF_INTOBJS( t_6, l_i, INTOBJ_INT(1) );
-   C_PROD_FIA( t_5, INTOBJ_INT(9), t_6 );
-   C_SUM_FIA( t_4, t_5, INTOBJ_INT(7) );
-   CHECK_INT_POS( t_4 );
-   C_ELM_LIST_FPL( t_3, l_methods, t_4 );
+   C_DIFF_INTOBJS( t_6, l_i, INTOBJ_INT(1) )
+   C_PROD_FIA( t_5, INTOBJ_INT(9), t_6 )
+   C_SUM_FIA( t_4, t_5, INTOBJ_INT(7) )
+   CHECK_INT_POS( t_4 )
+   C_ELM_LIST_FPL( t_3, l_methods, t_4 )
    RES_BRK_CURR_STAT();
    SWITCH_TO_OLD_FRAME(oldFrame);
    return t_3;
@@ -3231,7 +3231,7 @@ static Obj  HdlrFunc24 (
  
  /* return fail; */
  t_1 = GC_fail;
- CHECK_BOUND( t_1, "fail" );
+ CHECK_BOUND( t_1, "fail" )
  RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
@@ -3275,7 +3275,7 @@ static Obj  HdlrFunc25 (
  Obj t_17 = 0;
  Bag oldFrame;
  OLD_BRK_CURR_STAT
- CHECK_NR_ARGS( 7, args );
+ CHECK_NR_ARGS( 7, args )
  a_operation = ELM_PLIST( args, 1 );
  a_flags1 = ELM_PLIST( args, 2 );
  a_type2 = ELM_PLIST( args, 3 );
@@ -3292,15 +3292,15 @@ static Obj  HdlrFunc25 (
  /* methods := METHODS_OPERATION( operation, 6 ); */
  t_2 = GF_METHODS__OPERATION;
  t_1 = CALL_2ARGS( t_2, a_operation, INTOBJ_INT(6) );
- CHECK_FUNC_RESULT( t_1 );
+ CHECK_FUNC_RESULT( t_1 )
  l_methods = t_1;
  
  /* for i in [ 1 .. LEN_LIST( methods ) / 10 ] do */
  t_4 = GF_LEN__LIST;
  t_3 = CALL_1ARGS( t_4, l_methods );
- CHECK_FUNC_RESULT( t_3 );
+ CHECK_FUNC_RESULT( t_3 )
  t_2 = QUO( t_3, INTOBJ_INT(10) );
- CHECK_INT_SMALL( t_2 );
+ CHECK_INT_SMALL( t_2 )
  for ( t_1 = INTOBJ_INT(1);
        ((Int)t_1) <= ((Int)t_2);
        t_1 = (Obj)(((UInt)t_1)+4) ) {
@@ -3309,27 +3309,27 @@ static Obj  HdlrFunc25 (
   /* if IS_SUBSET_FLAGS( methods[10 * (i - 1) + 2], flags1 ) and IS_SUBSET_FLAGS( type2![2], methods[10 * (i - 1) + 3] ) and IS_SUBSET_FLAGS( type3![2], methods[10 * (i - 1) + 4] ) and IS_SUBSET_FLAGS( type4![2], methods[10 * (i - 1) + 5] ) 
     and IS_SUBSET_FLAGS( type5![2], methods[10 * (i - 1) + 6] ) and IS_SUBSET_FLAGS( type6![2], methods[10 * (i - 1) + 7] ) and methods[10 * (i - 1) + 1]( flags1, type2![1], type3![1], type4![1], type5![1], type6![1] ) then */
   t_11 = GF_IS__SUBSET__FLAGS;
-  C_DIFF_INTOBJS( t_15, l_i, INTOBJ_INT(1) );
-  C_PROD_FIA( t_14, INTOBJ_INT(10), t_15 );
-  C_SUM_FIA( t_13, t_14, INTOBJ_INT(2) );
-  CHECK_INT_POS( t_13 );
-  C_ELM_LIST_FPL( t_12, l_methods, t_13 );
+  C_DIFF_INTOBJS( t_15, l_i, INTOBJ_INT(1) )
+  C_PROD_FIA( t_14, INTOBJ_INT(10), t_15 )
+  C_SUM_FIA( t_13, t_14, INTOBJ_INT(2) )
+  CHECK_INT_POS( t_13 )
+  C_ELM_LIST_FPL( t_12, l_methods, t_13 )
   t_10 = CALL_2ARGS( t_11, t_12, a_flags1 );
-  CHECK_FUNC_RESULT( t_10 );
-  CHECK_BOOL( t_10 );
+  CHECK_FUNC_RESULT( t_10 )
+  CHECK_BOOL( t_10 )
   t_9 = (Obj)(UInt)(t_10 != False);
   t_8 = t_9;
   if ( t_8 ) {
    t_12 = GF_IS__SUBSET__FLAGS;
    C_ELM_POSOBJ_NLE( t_13, a_type2, 2 );
-   C_DIFF_INTOBJS( t_17, l_i, INTOBJ_INT(1) );
-   C_PROD_FIA( t_16, INTOBJ_INT(10), t_17 );
-   C_SUM_FIA( t_15, t_16, INTOBJ_INT(3) );
-   CHECK_INT_POS( t_15 );
-   C_ELM_LIST_FPL( t_14, l_methods, t_15 );
+   C_DIFF_INTOBJS( t_17, l_i, INTOBJ_INT(1) )
+   C_PROD_FIA( t_16, INTOBJ_INT(10), t_17 )
+   C_SUM_FIA( t_15, t_16, INTOBJ_INT(3) )
+   CHECK_INT_POS( t_15 )
+   C_ELM_LIST_FPL( t_14, l_methods, t_15 )
    t_11 = CALL_2ARGS( t_12, t_13, t_14 );
-   CHECK_FUNC_RESULT( t_11 );
-   CHECK_BOOL( t_11 );
+   CHECK_FUNC_RESULT( t_11 )
+   CHECK_BOOL( t_11 )
    t_10 = (Obj)(UInt)(t_11 != False);
    t_8 = t_10;
   }
@@ -3337,14 +3337,14 @@ static Obj  HdlrFunc25 (
   if ( t_7 ) {
    t_11 = GF_IS__SUBSET__FLAGS;
    C_ELM_POSOBJ_NLE( t_12, a_type3, 2 );
-   C_DIFF_INTOBJS( t_16, l_i, INTOBJ_INT(1) );
-   C_PROD_FIA( t_15, INTOBJ_INT(10), t_16 );
-   C_SUM_FIA( t_14, t_15, INTOBJ_INT(4) );
-   CHECK_INT_POS( t_14 );
-   C_ELM_LIST_FPL( t_13, l_methods, t_14 );
+   C_DIFF_INTOBJS( t_16, l_i, INTOBJ_INT(1) )
+   C_PROD_FIA( t_15, INTOBJ_INT(10), t_16 )
+   C_SUM_FIA( t_14, t_15, INTOBJ_INT(4) )
+   CHECK_INT_POS( t_14 )
+   C_ELM_LIST_FPL( t_13, l_methods, t_14 )
    t_10 = CALL_2ARGS( t_11, t_12, t_13 );
-   CHECK_FUNC_RESULT( t_10 );
-   CHECK_BOOL( t_10 );
+   CHECK_FUNC_RESULT( t_10 )
+   CHECK_BOOL( t_10 )
    t_9 = (Obj)(UInt)(t_10 != False);
    t_7 = t_9;
   }
@@ -3352,14 +3352,14 @@ static Obj  HdlrFunc25 (
   if ( t_6 ) {
    t_10 = GF_IS__SUBSET__FLAGS;
    C_ELM_POSOBJ_NLE( t_11, a_type4, 2 );
-   C_DIFF_INTOBJS( t_15, l_i, INTOBJ_INT(1) );
-   C_PROD_FIA( t_14, INTOBJ_INT(10), t_15 );
-   C_SUM_FIA( t_13, t_14, INTOBJ_INT(5) );
-   CHECK_INT_POS( t_13 );
-   C_ELM_LIST_FPL( t_12, l_methods, t_13 );
+   C_DIFF_INTOBJS( t_15, l_i, INTOBJ_INT(1) )
+   C_PROD_FIA( t_14, INTOBJ_INT(10), t_15 )
+   C_SUM_FIA( t_13, t_14, INTOBJ_INT(5) )
+   CHECK_INT_POS( t_13 )
+   C_ELM_LIST_FPL( t_12, l_methods, t_13 )
    t_9 = CALL_2ARGS( t_10, t_11, t_12 );
-   CHECK_FUNC_RESULT( t_9 );
-   CHECK_BOOL( t_9 );
+   CHECK_FUNC_RESULT( t_9 )
+   CHECK_BOOL( t_9 )
    t_8 = (Obj)(UInt)(t_9 != False);
    t_6 = t_8;
   }
@@ -3367,14 +3367,14 @@ static Obj  HdlrFunc25 (
   if ( t_5 ) {
    t_9 = GF_IS__SUBSET__FLAGS;
    C_ELM_POSOBJ_NLE( t_10, a_type5, 2 );
-   C_DIFF_INTOBJS( t_14, l_i, INTOBJ_INT(1) );
-   C_PROD_FIA( t_13, INTOBJ_INT(10), t_14 );
-   C_SUM_FIA( t_12, t_13, INTOBJ_INT(6) );
-   CHECK_INT_POS( t_12 );
-   C_ELM_LIST_FPL( t_11, l_methods, t_12 );
+   C_DIFF_INTOBJS( t_14, l_i, INTOBJ_INT(1) )
+   C_PROD_FIA( t_13, INTOBJ_INT(10), t_14 )
+   C_SUM_FIA( t_12, t_13, INTOBJ_INT(6) )
+   CHECK_INT_POS( t_12 )
+   C_ELM_LIST_FPL( t_11, l_methods, t_12 )
    t_8 = CALL_2ARGS( t_9, t_10, t_11 );
-   CHECK_FUNC_RESULT( t_8 );
-   CHECK_BOOL( t_8 );
+   CHECK_FUNC_RESULT( t_8 )
+   CHECK_BOOL( t_8 )
    t_7 = (Obj)(UInt)(t_8 != False);
    t_5 = t_7;
   }
@@ -3382,44 +3382,44 @@ static Obj  HdlrFunc25 (
   if ( t_4 ) {
    t_8 = GF_IS__SUBSET__FLAGS;
    C_ELM_POSOBJ_NLE( t_9, a_type6, 2 );
-   C_DIFF_INTOBJS( t_13, l_i, INTOBJ_INT(1) );
-   C_PROD_FIA( t_12, INTOBJ_INT(10), t_13 );
-   C_SUM_FIA( t_11, t_12, INTOBJ_INT(7) );
-   CHECK_INT_POS( t_11 );
-   C_ELM_LIST_FPL( t_10, l_methods, t_11 );
+   C_DIFF_INTOBJS( t_13, l_i, INTOBJ_INT(1) )
+   C_PROD_FIA( t_12, INTOBJ_INT(10), t_13 )
+   C_SUM_FIA( t_11, t_12, INTOBJ_INT(7) )
+   CHECK_INT_POS( t_11 )
+   C_ELM_LIST_FPL( t_10, l_methods, t_11 )
    t_7 = CALL_2ARGS( t_8, t_9, t_10 );
-   CHECK_FUNC_RESULT( t_7 );
-   CHECK_BOOL( t_7 );
+   CHECK_FUNC_RESULT( t_7 )
+   CHECK_BOOL( t_7 )
    t_6 = (Obj)(UInt)(t_7 != False);
    t_4 = t_6;
   }
   t_3 = t_4;
   if ( t_3 ) {
-   C_DIFF_INTOBJS( t_10, l_i, INTOBJ_INT(1) );
-   C_PROD_FIA( t_9, INTOBJ_INT(10), t_10 );
-   C_SUM_FIA( t_8, t_9, INTOBJ_INT(1) );
-   CHECK_INT_POS( t_8 );
-   C_ELM_LIST_FPL( t_7, l_methods, t_8 );
-   CHECK_FUNC( t_7 );
+   C_DIFF_INTOBJS( t_10, l_i, INTOBJ_INT(1) )
+   C_PROD_FIA( t_9, INTOBJ_INT(10), t_10 )
+   C_SUM_FIA( t_8, t_9, INTOBJ_INT(1) )
+   CHECK_INT_POS( t_8 )
+   C_ELM_LIST_FPL( t_7, l_methods, t_8 )
+   CHECK_FUNC( t_7 )
    C_ELM_POSOBJ_NLE( t_8, a_type2, 1 );
    C_ELM_POSOBJ_NLE( t_9, a_type3, 1 );
    C_ELM_POSOBJ_NLE( t_10, a_type4, 1 );
    C_ELM_POSOBJ_NLE( t_11, a_type5, 1 );
    C_ELM_POSOBJ_NLE( t_12, a_type6, 1 );
    t_6 = CALL_6ARGS( t_7, a_flags1, t_8, t_9, t_10, t_11, t_12 );
-   CHECK_FUNC_RESULT( t_6 );
-   CHECK_BOOL( t_6 );
+   CHECK_FUNC_RESULT( t_6 )
+   CHECK_BOOL( t_6 )
    t_5 = (Obj)(UInt)(t_6 != False);
    t_3 = t_5;
   }
   if ( t_3 ) {
    
    /* return methods[10 * (i - 1) + 8]; */
-   C_DIFF_INTOBJS( t_6, l_i, INTOBJ_INT(1) );
-   C_PROD_FIA( t_5, INTOBJ_INT(10), t_6 );
-   C_SUM_FIA( t_4, t_5, INTOBJ_INT(8) );
-   CHECK_INT_POS( t_4 );
-   C_ELM_LIST_FPL( t_3, l_methods, t_4 );
+   C_DIFF_INTOBJS( t_6, l_i, INTOBJ_INT(1) )
+   C_PROD_FIA( t_5, INTOBJ_INT(10), t_6 )
+   C_SUM_FIA( t_4, t_5, INTOBJ_INT(8) )
+   CHECK_INT_POS( t_4 )
+   C_ELM_LIST_FPL( t_3, l_methods, t_4 )
    RES_BRK_CURR_STAT();
    SWITCH_TO_OLD_FRAME(oldFrame);
    return t_3;
@@ -3432,7 +3432,7 @@ static Obj  HdlrFunc25 (
  
  /* return fail; */
  t_1 = GC_fail;
- CHECK_BOUND( t_1, "fail" );
+ CHECK_BOUND( t_1, "fail" )
  RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
@@ -3502,7 +3502,7 @@ static Obj  HdlrFunc27 (
  /* methods := METHODS_OPERATION( operation, 0 ); */
  t_2 = GF_METHODS__OPERATION;
  t_1 = CALL_2ARGS( t_2, a_operation, INTOBJ_INT(0) );
- CHECK_FUNC_RESULT( t_1 );
+ CHECK_FUNC_RESULT( t_1 )
  l_methods = t_1;
  
  /* j := 0; */
@@ -3511,24 +3511,24 @@ static Obj  HdlrFunc27 (
  /* for i in [ 1 .. LEN_LIST( methods ) / 4 ] do */
  t_4 = GF_LEN__LIST;
  t_3 = CALL_1ARGS( t_4, l_methods );
- CHECK_FUNC_RESULT( t_3 );
+ CHECK_FUNC_RESULT( t_3 )
  t_2 = QUO( t_3, INTOBJ_INT(4) );
- CHECK_INT_SMALL( t_2 );
+ CHECK_INT_SMALL( t_2 )
  for ( t_1 = INTOBJ_INT(1);
        ((Int)t_1) <= ((Int)t_2);
        t_1 = (Obj)(((UInt)t_1)+4) ) {
   l_i = t_1;
   
   /* if methods[4 * (i - 1) + 1](  ) then */
-  C_DIFF_INTOBJS( t_8, l_i, INTOBJ_INT(1) );
-  C_PROD_FIA( t_7, INTOBJ_INT(4), t_8 );
-  C_SUM_FIA( t_6, t_7, INTOBJ_INT(1) );
-  CHECK_INT_POS( t_6 );
-  C_ELM_LIST_FPL( t_5, l_methods, t_6 );
-  CHECK_FUNC( t_5 );
+  C_DIFF_INTOBJS( t_8, l_i, INTOBJ_INT(1) )
+  C_PROD_FIA( t_7, INTOBJ_INT(4), t_8 )
+  C_SUM_FIA( t_6, t_7, INTOBJ_INT(1) )
+  CHECK_INT_POS( t_6 )
+  C_ELM_LIST_FPL( t_5, l_methods, t_6 )
+  CHECK_FUNC( t_5 )
   t_4 = CALL_0ARGS( t_5 );
-  CHECK_FUNC_RESULT( t_4 );
-  CHECK_BOOL( t_4 );
+  CHECK_FUNC_RESULT( t_4 )
+  CHECK_BOOL( t_4 )
   t_3 = (Obj)(UInt)(t_4 != False);
   if ( t_3 ) {
    
@@ -3537,11 +3537,11 @@ static Obj  HdlrFunc27 (
    if ( t_3 ) {
     
     /* return methods[4 * (i - 1) + 2]; */
-    C_DIFF_INTOBJS( t_6, l_i, INTOBJ_INT(1) );
-    C_PROD_FIA( t_5, INTOBJ_INT(4), t_6 );
-    C_SUM_FIA( t_4, t_5, INTOBJ_INT(2) );
-    CHECK_INT_POS( t_4 );
-    C_ELM_LIST_FPL( t_3, l_methods, t_4 );
+    C_DIFF_INTOBJS( t_6, l_i, INTOBJ_INT(1) )
+    C_PROD_FIA( t_5, INTOBJ_INT(4), t_6 )
+    C_SUM_FIA( t_4, t_5, INTOBJ_INT(2) )
+    CHECK_INT_POS( t_4 )
+    C_ELM_LIST_FPL( t_3, l_methods, t_4 )
     RES_BRK_CURR_STAT();
     SWITCH_TO_OLD_FRAME(oldFrame);
     return t_3;
@@ -3552,7 +3552,7 @@ static Obj  HdlrFunc27 (
    else {
     
     /* j := j + 1; */
-    C_SUM_FIA( t_3, l_j, INTOBJ_INT(1) );
+    C_SUM_FIA( t_3, l_j, INTOBJ_INT(1) )
     l_j = t_3;
     
    }
@@ -3566,7 +3566,7 @@ static Obj  HdlrFunc27 (
  
  /* return fail; */
  t_1 = GC_fail;
- CHECK_BOUND( t_1, "fail" );
+ CHECK_BOUND( t_1, "fail" )
  RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
@@ -3608,7 +3608,7 @@ static Obj  HdlrFunc28 (
  /* methods := METHODS_OPERATION( operation, 1 ); */
  t_2 = GF_METHODS__OPERATION;
  t_1 = CALL_2ARGS( t_2, a_operation, INTOBJ_INT(1) );
- CHECK_FUNC_RESULT( t_1 );
+ CHECK_FUNC_RESULT( t_1 )
  l_methods = t_1;
  
  /* j := 0; */
@@ -3617,9 +3617,9 @@ static Obj  HdlrFunc28 (
  /* for i in [ 1 .. LEN_LIST( methods ) / 5 ] do */
  t_4 = GF_LEN__LIST;
  t_3 = CALL_1ARGS( t_4, l_methods );
- CHECK_FUNC_RESULT( t_3 );
+ CHECK_FUNC_RESULT( t_3 )
  t_2 = QUO( t_3, INTOBJ_INT(5) );
- CHECK_INT_SMALL( t_2 );
+ CHECK_INT_SMALL( t_2 )
  for ( t_1 = INTOBJ_INT(1);
        ((Int)t_1) <= ((Int)t_2);
        t_1 = (Obj)(((UInt)t_1)+4) ) {
@@ -3627,26 +3627,26 @@ static Obj  HdlrFunc28 (
   
   /* if IS_SUBSET_FLAGS( methods[5 * (i - 1) + 2], flags1 ) and methods[5 * (i - 1) + 1]( flags1 ) then */
   t_6 = GF_IS__SUBSET__FLAGS;
-  C_DIFF_INTOBJS( t_10, l_i, INTOBJ_INT(1) );
-  C_PROD_FIA( t_9, INTOBJ_INT(5), t_10 );
-  C_SUM_FIA( t_8, t_9, INTOBJ_INT(2) );
-  CHECK_INT_POS( t_8 );
-  C_ELM_LIST_FPL( t_7, l_methods, t_8 );
+  C_DIFF_INTOBJS( t_10, l_i, INTOBJ_INT(1) )
+  C_PROD_FIA( t_9, INTOBJ_INT(5), t_10 )
+  C_SUM_FIA( t_8, t_9, INTOBJ_INT(2) )
+  CHECK_INT_POS( t_8 )
+  C_ELM_LIST_FPL( t_7, l_methods, t_8 )
   t_5 = CALL_2ARGS( t_6, t_7, a_flags1 );
-  CHECK_FUNC_RESULT( t_5 );
-  CHECK_BOOL( t_5 );
+  CHECK_FUNC_RESULT( t_5 )
+  CHECK_BOOL( t_5 )
   t_4 = (Obj)(UInt)(t_5 != False);
   t_3 = t_4;
   if ( t_3 ) {
-   C_DIFF_INTOBJS( t_10, l_i, INTOBJ_INT(1) );
-   C_PROD_FIA( t_9, INTOBJ_INT(5), t_10 );
-   C_SUM_FIA( t_8, t_9, INTOBJ_INT(1) );
-   CHECK_INT_POS( t_8 );
-   C_ELM_LIST_FPL( t_7, l_methods, t_8 );
-   CHECK_FUNC( t_7 );
+   C_DIFF_INTOBJS( t_10, l_i, INTOBJ_INT(1) )
+   C_PROD_FIA( t_9, INTOBJ_INT(5), t_10 )
+   C_SUM_FIA( t_8, t_9, INTOBJ_INT(1) )
+   CHECK_INT_POS( t_8 )
+   C_ELM_LIST_FPL( t_7, l_methods, t_8 )
+   CHECK_FUNC( t_7 )
    t_6 = CALL_1ARGS( t_7, a_flags1 );
-   CHECK_FUNC_RESULT( t_6 );
-   CHECK_BOOL( t_6 );
+   CHECK_FUNC_RESULT( t_6 )
+   CHECK_BOOL( t_6 )
    t_5 = (Obj)(UInt)(t_6 != False);
    t_3 = t_5;
   }
@@ -3657,11 +3657,11 @@ static Obj  HdlrFunc28 (
    if ( t_3 ) {
     
     /* return methods[5 * (i - 1) + 3]; */
-    C_DIFF_INTOBJS( t_6, l_i, INTOBJ_INT(1) );
-    C_PROD_FIA( t_5, INTOBJ_INT(5), t_6 );
-    C_SUM_FIA( t_4, t_5, INTOBJ_INT(3) );
-    CHECK_INT_POS( t_4 );
-    C_ELM_LIST_FPL( t_3, l_methods, t_4 );
+    C_DIFF_INTOBJS( t_6, l_i, INTOBJ_INT(1) )
+    C_PROD_FIA( t_5, INTOBJ_INT(5), t_6 )
+    C_SUM_FIA( t_4, t_5, INTOBJ_INT(3) )
+    CHECK_INT_POS( t_4 )
+    C_ELM_LIST_FPL( t_3, l_methods, t_4 )
     RES_BRK_CURR_STAT();
     SWITCH_TO_OLD_FRAME(oldFrame);
     return t_3;
@@ -3672,7 +3672,7 @@ static Obj  HdlrFunc28 (
    else {
     
     /* j := j + 1; */
-    C_SUM_FIA( t_3, l_j, INTOBJ_INT(1) );
+    C_SUM_FIA( t_3, l_j, INTOBJ_INT(1) )
     l_j = t_3;
     
    }
@@ -3686,7 +3686,7 @@ static Obj  HdlrFunc28 (
  
  /* return fail; */
  t_1 = GC_fail;
- CHECK_BOUND( t_1, "fail" );
+ CHECK_BOUND( t_1, "fail" )
  RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
@@ -3732,7 +3732,7 @@ static Obj  HdlrFunc29 (
  /* methods := METHODS_OPERATION( operation, 2 ); */
  t_2 = GF_METHODS__OPERATION;
  t_1 = CALL_2ARGS( t_2, a_operation, INTOBJ_INT(2) );
- CHECK_FUNC_RESULT( t_1 );
+ CHECK_FUNC_RESULT( t_1 )
  l_methods = t_1;
  
  /* j := 0; */
@@ -3741,9 +3741,9 @@ static Obj  HdlrFunc29 (
  /* for i in [ 1 .. LEN_LIST( methods ) / 6 ] do */
  t_4 = GF_LEN__LIST;
  t_3 = CALL_1ARGS( t_4, l_methods );
- CHECK_FUNC_RESULT( t_3 );
+ CHECK_FUNC_RESULT( t_3 )
  t_2 = QUO( t_3, INTOBJ_INT(6) );
- CHECK_INT_SMALL( t_2 );
+ CHECK_INT_SMALL( t_2 )
  for ( t_1 = INTOBJ_INT(1);
        ((Int)t_1) <= ((Int)t_2);
        t_1 = (Obj)(((UInt)t_1)+4) ) {
@@ -3751,42 +3751,42 @@ static Obj  HdlrFunc29 (
   
   /* if IS_SUBSET_FLAGS( methods[6 * (i - 1) + 2], flags1 ) and IS_SUBSET_FLAGS( type2![2], methods[6 * (i - 1) + 3] ) and methods[6 * (i - 1) + 1]( flags1, type2![1] ) then */
   t_7 = GF_IS__SUBSET__FLAGS;
-  C_DIFF_INTOBJS( t_11, l_i, INTOBJ_INT(1) );
-  C_PROD_FIA( t_10, INTOBJ_INT(6), t_11 );
-  C_SUM_FIA( t_9, t_10, INTOBJ_INT(2) );
-  CHECK_INT_POS( t_9 );
-  C_ELM_LIST_FPL( t_8, l_methods, t_9 );
+  C_DIFF_INTOBJS( t_11, l_i, INTOBJ_INT(1) )
+  C_PROD_FIA( t_10, INTOBJ_INT(6), t_11 )
+  C_SUM_FIA( t_9, t_10, INTOBJ_INT(2) )
+  CHECK_INT_POS( t_9 )
+  C_ELM_LIST_FPL( t_8, l_methods, t_9 )
   t_6 = CALL_2ARGS( t_7, t_8, a_flags1 );
-  CHECK_FUNC_RESULT( t_6 );
-  CHECK_BOOL( t_6 );
+  CHECK_FUNC_RESULT( t_6 )
+  CHECK_BOOL( t_6 )
   t_5 = (Obj)(UInt)(t_6 != False);
   t_4 = t_5;
   if ( t_4 ) {
    t_8 = GF_IS__SUBSET__FLAGS;
    C_ELM_POSOBJ_NLE( t_9, a_type2, 2 );
-   C_DIFF_INTOBJS( t_13, l_i, INTOBJ_INT(1) );
-   C_PROD_FIA( t_12, INTOBJ_INT(6), t_13 );
-   C_SUM_FIA( t_11, t_12, INTOBJ_INT(3) );
-   CHECK_INT_POS( t_11 );
-   C_ELM_LIST_FPL( t_10, l_methods, t_11 );
+   C_DIFF_INTOBJS( t_13, l_i, INTOBJ_INT(1) )
+   C_PROD_FIA( t_12, INTOBJ_INT(6), t_13 )
+   C_SUM_FIA( t_11, t_12, INTOBJ_INT(3) )
+   CHECK_INT_POS( t_11 )
+   C_ELM_LIST_FPL( t_10, l_methods, t_11 )
    t_7 = CALL_2ARGS( t_8, t_9, t_10 );
-   CHECK_FUNC_RESULT( t_7 );
-   CHECK_BOOL( t_7 );
+   CHECK_FUNC_RESULT( t_7 )
+   CHECK_BOOL( t_7 )
    t_6 = (Obj)(UInt)(t_7 != False);
    t_4 = t_6;
   }
   t_3 = t_4;
   if ( t_3 ) {
-   C_DIFF_INTOBJS( t_10, l_i, INTOBJ_INT(1) );
-   C_PROD_FIA( t_9, INTOBJ_INT(6), t_10 );
-   C_SUM_FIA( t_8, t_9, INTOBJ_INT(1) );
-   CHECK_INT_POS( t_8 );
-   C_ELM_LIST_FPL( t_7, l_methods, t_8 );
-   CHECK_FUNC( t_7 );
+   C_DIFF_INTOBJS( t_10, l_i, INTOBJ_INT(1) )
+   C_PROD_FIA( t_9, INTOBJ_INT(6), t_10 )
+   C_SUM_FIA( t_8, t_9, INTOBJ_INT(1) )
+   CHECK_INT_POS( t_8 )
+   C_ELM_LIST_FPL( t_7, l_methods, t_8 )
+   CHECK_FUNC( t_7 )
    C_ELM_POSOBJ_NLE( t_8, a_type2, 1 );
    t_6 = CALL_2ARGS( t_7, a_flags1, t_8 );
-   CHECK_FUNC_RESULT( t_6 );
-   CHECK_BOOL( t_6 );
+   CHECK_FUNC_RESULT( t_6 )
+   CHECK_BOOL( t_6 )
    t_5 = (Obj)(UInt)(t_6 != False);
    t_3 = t_5;
   }
@@ -3797,11 +3797,11 @@ static Obj  HdlrFunc29 (
    if ( t_3 ) {
     
     /* return methods[6 * (i - 1) + 4]; */
-    C_DIFF_INTOBJS( t_6, l_i, INTOBJ_INT(1) );
-    C_PROD_FIA( t_5, INTOBJ_INT(6), t_6 );
-    C_SUM_FIA( t_4, t_5, INTOBJ_INT(4) );
-    CHECK_INT_POS( t_4 );
-    C_ELM_LIST_FPL( t_3, l_methods, t_4 );
+    C_DIFF_INTOBJS( t_6, l_i, INTOBJ_INT(1) )
+    C_PROD_FIA( t_5, INTOBJ_INT(6), t_6 )
+    C_SUM_FIA( t_4, t_5, INTOBJ_INT(4) )
+    CHECK_INT_POS( t_4 )
+    C_ELM_LIST_FPL( t_3, l_methods, t_4 )
     RES_BRK_CURR_STAT();
     SWITCH_TO_OLD_FRAME(oldFrame);
     return t_3;
@@ -3812,7 +3812,7 @@ static Obj  HdlrFunc29 (
    else {
     
     /* j := j + 1; */
-    C_SUM_FIA( t_3, l_j, INTOBJ_INT(1) );
+    C_SUM_FIA( t_3, l_j, INTOBJ_INT(1) )
     l_j = t_3;
     
    }
@@ -3826,7 +3826,7 @@ static Obj  HdlrFunc29 (
  
  /* return fail; */
  t_1 = GC_fail;
- CHECK_BOUND( t_1, "fail" );
+ CHECK_BOUND( t_1, "fail" )
  RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
@@ -3874,7 +3874,7 @@ static Obj  HdlrFunc30 (
  /* methods := METHODS_OPERATION( operation, 3 ); */
  t_2 = GF_METHODS__OPERATION;
  t_1 = CALL_2ARGS( t_2, a_operation, INTOBJ_INT(3) );
- CHECK_FUNC_RESULT( t_1 );
+ CHECK_FUNC_RESULT( t_1 )
  l_methods = t_1;
  
  /* j := 0; */
@@ -3883,9 +3883,9 @@ static Obj  HdlrFunc30 (
  /* for i in [ 1 .. LEN_LIST( methods ) / 7 ] do */
  t_4 = GF_LEN__LIST;
  t_3 = CALL_1ARGS( t_4, l_methods );
- CHECK_FUNC_RESULT( t_3 );
+ CHECK_FUNC_RESULT( t_3 )
  t_2 = QUO( t_3, INTOBJ_INT(7) );
- CHECK_INT_SMALL( t_2 );
+ CHECK_INT_SMALL( t_2 )
  for ( t_1 = INTOBJ_INT(1);
        ((Int)t_1) <= ((Int)t_2);
        t_1 = (Obj)(((UInt)t_1)+4) ) {
@@ -3893,27 +3893,27 @@ static Obj  HdlrFunc30 (
   
   /* if IS_SUBSET_FLAGS( methods[7 * (i - 1) + 2], flags1 ) and IS_SUBSET_FLAGS( type2![2], methods[7 * (i - 1) + 3] ) and IS_SUBSET_FLAGS( type3![2], methods[7 * (i - 1) + 4] ) and methods[7 * (i - 1) + 1]( flags1, type2![1], type3![1] ) then */
   t_8 = GF_IS__SUBSET__FLAGS;
-  C_DIFF_INTOBJS( t_12, l_i, INTOBJ_INT(1) );
-  C_PROD_FIA( t_11, INTOBJ_INT(7), t_12 );
-  C_SUM_FIA( t_10, t_11, INTOBJ_INT(2) );
-  CHECK_INT_POS( t_10 );
-  C_ELM_LIST_FPL( t_9, l_methods, t_10 );
+  C_DIFF_INTOBJS( t_12, l_i, INTOBJ_INT(1) )
+  C_PROD_FIA( t_11, INTOBJ_INT(7), t_12 )
+  C_SUM_FIA( t_10, t_11, INTOBJ_INT(2) )
+  CHECK_INT_POS( t_10 )
+  C_ELM_LIST_FPL( t_9, l_methods, t_10 )
   t_7 = CALL_2ARGS( t_8, t_9, a_flags1 );
-  CHECK_FUNC_RESULT( t_7 );
-  CHECK_BOOL( t_7 );
+  CHECK_FUNC_RESULT( t_7 )
+  CHECK_BOOL( t_7 )
   t_6 = (Obj)(UInt)(t_7 != False);
   t_5 = t_6;
   if ( t_5 ) {
    t_9 = GF_IS__SUBSET__FLAGS;
    C_ELM_POSOBJ_NLE( t_10, a_type2, 2 );
-   C_DIFF_INTOBJS( t_14, l_i, INTOBJ_INT(1) );
-   C_PROD_FIA( t_13, INTOBJ_INT(7), t_14 );
-   C_SUM_FIA( t_12, t_13, INTOBJ_INT(3) );
-   CHECK_INT_POS( t_12 );
-   C_ELM_LIST_FPL( t_11, l_methods, t_12 );
+   C_DIFF_INTOBJS( t_14, l_i, INTOBJ_INT(1) )
+   C_PROD_FIA( t_13, INTOBJ_INT(7), t_14 )
+   C_SUM_FIA( t_12, t_13, INTOBJ_INT(3) )
+   CHECK_INT_POS( t_12 )
+   C_ELM_LIST_FPL( t_11, l_methods, t_12 )
    t_8 = CALL_2ARGS( t_9, t_10, t_11 );
-   CHECK_FUNC_RESULT( t_8 );
-   CHECK_BOOL( t_8 );
+   CHECK_FUNC_RESULT( t_8 )
+   CHECK_BOOL( t_8 )
    t_7 = (Obj)(UInt)(t_8 != False);
    t_5 = t_7;
   }
@@ -3921,30 +3921,30 @@ static Obj  HdlrFunc30 (
   if ( t_4 ) {
    t_8 = GF_IS__SUBSET__FLAGS;
    C_ELM_POSOBJ_NLE( t_9, a_type3, 2 );
-   C_DIFF_INTOBJS( t_13, l_i, INTOBJ_INT(1) );
-   C_PROD_FIA( t_12, INTOBJ_INT(7), t_13 );
-   C_SUM_FIA( t_11, t_12, INTOBJ_INT(4) );
-   CHECK_INT_POS( t_11 );
-   C_ELM_LIST_FPL( t_10, l_methods, t_11 );
+   C_DIFF_INTOBJS( t_13, l_i, INTOBJ_INT(1) )
+   C_PROD_FIA( t_12, INTOBJ_INT(7), t_13 )
+   C_SUM_FIA( t_11, t_12, INTOBJ_INT(4) )
+   CHECK_INT_POS( t_11 )
+   C_ELM_LIST_FPL( t_10, l_methods, t_11 )
    t_7 = CALL_2ARGS( t_8, t_9, t_10 );
-   CHECK_FUNC_RESULT( t_7 );
-   CHECK_BOOL( t_7 );
+   CHECK_FUNC_RESULT( t_7 )
+   CHECK_BOOL( t_7 )
    t_6 = (Obj)(UInt)(t_7 != False);
    t_4 = t_6;
   }
   t_3 = t_4;
   if ( t_3 ) {
-   C_DIFF_INTOBJS( t_10, l_i, INTOBJ_INT(1) );
-   C_PROD_FIA( t_9, INTOBJ_INT(7), t_10 );
-   C_SUM_FIA( t_8, t_9, INTOBJ_INT(1) );
-   CHECK_INT_POS( t_8 );
-   C_ELM_LIST_FPL( t_7, l_methods, t_8 );
-   CHECK_FUNC( t_7 );
+   C_DIFF_INTOBJS( t_10, l_i, INTOBJ_INT(1) )
+   C_PROD_FIA( t_9, INTOBJ_INT(7), t_10 )
+   C_SUM_FIA( t_8, t_9, INTOBJ_INT(1) )
+   CHECK_INT_POS( t_8 )
+   C_ELM_LIST_FPL( t_7, l_methods, t_8 )
+   CHECK_FUNC( t_7 )
    C_ELM_POSOBJ_NLE( t_8, a_type2, 1 );
    C_ELM_POSOBJ_NLE( t_9, a_type3, 1 );
    t_6 = CALL_3ARGS( t_7, a_flags1, t_8, t_9 );
-   CHECK_FUNC_RESULT( t_6 );
-   CHECK_BOOL( t_6 );
+   CHECK_FUNC_RESULT( t_6 )
+   CHECK_BOOL( t_6 )
    t_5 = (Obj)(UInt)(t_6 != False);
    t_3 = t_5;
   }
@@ -3955,11 +3955,11 @@ static Obj  HdlrFunc30 (
    if ( t_3 ) {
     
     /* return methods[7 * (i - 1) + 5]; */
-    C_DIFF_INTOBJS( t_6, l_i, INTOBJ_INT(1) );
-    C_PROD_FIA( t_5, INTOBJ_INT(7), t_6 );
-    C_SUM_FIA( t_4, t_5, INTOBJ_INT(5) );
-    CHECK_INT_POS( t_4 );
-    C_ELM_LIST_FPL( t_3, l_methods, t_4 );
+    C_DIFF_INTOBJS( t_6, l_i, INTOBJ_INT(1) )
+    C_PROD_FIA( t_5, INTOBJ_INT(7), t_6 )
+    C_SUM_FIA( t_4, t_5, INTOBJ_INT(5) )
+    CHECK_INT_POS( t_4 )
+    C_ELM_LIST_FPL( t_3, l_methods, t_4 )
     RES_BRK_CURR_STAT();
     SWITCH_TO_OLD_FRAME(oldFrame);
     return t_3;
@@ -3970,7 +3970,7 @@ static Obj  HdlrFunc30 (
    else {
     
     /* j := j + 1; */
-    C_SUM_FIA( t_3, l_j, INTOBJ_INT(1) );
+    C_SUM_FIA( t_3, l_j, INTOBJ_INT(1) )
     l_j = t_3;
     
    }
@@ -3984,7 +3984,7 @@ static Obj  HdlrFunc30 (
  
  /* return fail; */
  t_1 = GC_fail;
- CHECK_BOUND( t_1, "fail" );
+ CHECK_BOUND( t_1, "fail" )
  RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
@@ -4034,7 +4034,7 @@ static Obj  HdlrFunc31 (
  /* methods := METHODS_OPERATION( operation, 4 ); */
  t_2 = GF_METHODS__OPERATION;
  t_1 = CALL_2ARGS( t_2, a_operation, INTOBJ_INT(4) );
- CHECK_FUNC_RESULT( t_1 );
+ CHECK_FUNC_RESULT( t_1 )
  l_methods = t_1;
  
  /* j := 0; */
@@ -4043,9 +4043,9 @@ static Obj  HdlrFunc31 (
  /* for i in [ 1 .. LEN_LIST( methods ) / 8 ] do */
  t_4 = GF_LEN__LIST;
  t_3 = CALL_1ARGS( t_4, l_methods );
- CHECK_FUNC_RESULT( t_3 );
+ CHECK_FUNC_RESULT( t_3 )
  t_2 = QUO( t_3, INTOBJ_INT(8) );
- CHECK_INT_SMALL( t_2 );
+ CHECK_INT_SMALL( t_2 )
  for ( t_1 = INTOBJ_INT(1);
        ((Int)t_1) <= ((Int)t_2);
        t_1 = (Obj)(((UInt)t_1)+4) ) {
@@ -4054,27 +4054,27 @@ static Obj  HdlrFunc31 (
   /* if IS_SUBSET_FLAGS( methods[8 * (i - 1) + 2], flags1 ) and IS_SUBSET_FLAGS( type2![2], methods[8 * (i - 1) + 3] ) and IS_SUBSET_FLAGS( type3![2], methods[8 * (i - 1) + 4] ) and IS_SUBSET_FLAGS( type4![2], methods[8 * (i - 1) + 5] ) 
 and methods[8 * (i - 1) + 1]( flags1, type2![1], type3![1], type4![1] ) then */
   t_9 = GF_IS__SUBSET__FLAGS;
-  C_DIFF_INTOBJS( t_13, l_i, INTOBJ_INT(1) );
-  C_PROD_FIA( t_12, INTOBJ_INT(8), t_13 );
-  C_SUM_FIA( t_11, t_12, INTOBJ_INT(2) );
-  CHECK_INT_POS( t_11 );
-  C_ELM_LIST_FPL( t_10, l_methods, t_11 );
+  C_DIFF_INTOBJS( t_13, l_i, INTOBJ_INT(1) )
+  C_PROD_FIA( t_12, INTOBJ_INT(8), t_13 )
+  C_SUM_FIA( t_11, t_12, INTOBJ_INT(2) )
+  CHECK_INT_POS( t_11 )
+  C_ELM_LIST_FPL( t_10, l_methods, t_11 )
   t_8 = CALL_2ARGS( t_9, t_10, a_flags1 );
-  CHECK_FUNC_RESULT( t_8 );
-  CHECK_BOOL( t_8 );
+  CHECK_FUNC_RESULT( t_8 )
+  CHECK_BOOL( t_8 )
   t_7 = (Obj)(UInt)(t_8 != False);
   t_6 = t_7;
   if ( t_6 ) {
    t_10 = GF_IS__SUBSET__FLAGS;
    C_ELM_POSOBJ_NLE( t_11, a_type2, 2 );
-   C_DIFF_INTOBJS( t_15, l_i, INTOBJ_INT(1) );
-   C_PROD_FIA( t_14, INTOBJ_INT(8), t_15 );
-   C_SUM_FIA( t_13, t_14, INTOBJ_INT(3) );
-   CHECK_INT_POS( t_13 );
-   C_ELM_LIST_FPL( t_12, l_methods, t_13 );
+   C_DIFF_INTOBJS( t_15, l_i, INTOBJ_INT(1) )
+   C_PROD_FIA( t_14, INTOBJ_INT(8), t_15 )
+   C_SUM_FIA( t_13, t_14, INTOBJ_INT(3) )
+   CHECK_INT_POS( t_13 )
+   C_ELM_LIST_FPL( t_12, l_methods, t_13 )
    t_9 = CALL_2ARGS( t_10, t_11, t_12 );
-   CHECK_FUNC_RESULT( t_9 );
-   CHECK_BOOL( t_9 );
+   CHECK_FUNC_RESULT( t_9 )
+   CHECK_BOOL( t_9 )
    t_8 = (Obj)(UInt)(t_9 != False);
    t_6 = t_8;
   }
@@ -4082,14 +4082,14 @@ and methods[8 * (i - 1) + 1]( flags1, type2![1], type3![1], type4![1] ) then */
   if ( t_5 ) {
    t_9 = GF_IS__SUBSET__FLAGS;
    C_ELM_POSOBJ_NLE( t_10, a_type3, 2 );
-   C_DIFF_INTOBJS( t_14, l_i, INTOBJ_INT(1) );
-   C_PROD_FIA( t_13, INTOBJ_INT(8), t_14 );
-   C_SUM_FIA( t_12, t_13, INTOBJ_INT(4) );
-   CHECK_INT_POS( t_12 );
-   C_ELM_LIST_FPL( t_11, l_methods, t_12 );
+   C_DIFF_INTOBJS( t_14, l_i, INTOBJ_INT(1) )
+   C_PROD_FIA( t_13, INTOBJ_INT(8), t_14 )
+   C_SUM_FIA( t_12, t_13, INTOBJ_INT(4) )
+   CHECK_INT_POS( t_12 )
+   C_ELM_LIST_FPL( t_11, l_methods, t_12 )
    t_8 = CALL_2ARGS( t_9, t_10, t_11 );
-   CHECK_FUNC_RESULT( t_8 );
-   CHECK_BOOL( t_8 );
+   CHECK_FUNC_RESULT( t_8 )
+   CHECK_BOOL( t_8 )
    t_7 = (Obj)(UInt)(t_8 != False);
    t_5 = t_7;
   }
@@ -4097,31 +4097,31 @@ and methods[8 * (i - 1) + 1]( flags1, type2![1], type3![1], type4![1] ) then */
   if ( t_4 ) {
    t_8 = GF_IS__SUBSET__FLAGS;
    C_ELM_POSOBJ_NLE( t_9, a_type4, 2 );
-   C_DIFF_INTOBJS( t_13, l_i, INTOBJ_INT(1) );
-   C_PROD_FIA( t_12, INTOBJ_INT(8), t_13 );
-   C_SUM_FIA( t_11, t_12, INTOBJ_INT(5) );
-   CHECK_INT_POS( t_11 );
-   C_ELM_LIST_FPL( t_10, l_methods, t_11 );
+   C_DIFF_INTOBJS( t_13, l_i, INTOBJ_INT(1) )
+   C_PROD_FIA( t_12, INTOBJ_INT(8), t_13 )
+   C_SUM_FIA( t_11, t_12, INTOBJ_INT(5) )
+   CHECK_INT_POS( t_11 )
+   C_ELM_LIST_FPL( t_10, l_methods, t_11 )
    t_7 = CALL_2ARGS( t_8, t_9, t_10 );
-   CHECK_FUNC_RESULT( t_7 );
-   CHECK_BOOL( t_7 );
+   CHECK_FUNC_RESULT( t_7 )
+   CHECK_BOOL( t_7 )
    t_6 = (Obj)(UInt)(t_7 != False);
    t_4 = t_6;
   }
   t_3 = t_4;
   if ( t_3 ) {
-   C_DIFF_INTOBJS( t_10, l_i, INTOBJ_INT(1) );
-   C_PROD_FIA( t_9, INTOBJ_INT(8), t_10 );
-   C_SUM_FIA( t_8, t_9, INTOBJ_INT(1) );
-   CHECK_INT_POS( t_8 );
-   C_ELM_LIST_FPL( t_7, l_methods, t_8 );
-   CHECK_FUNC( t_7 );
+   C_DIFF_INTOBJS( t_10, l_i, INTOBJ_INT(1) )
+   C_PROD_FIA( t_9, INTOBJ_INT(8), t_10 )
+   C_SUM_FIA( t_8, t_9, INTOBJ_INT(1) )
+   CHECK_INT_POS( t_8 )
+   C_ELM_LIST_FPL( t_7, l_methods, t_8 )
+   CHECK_FUNC( t_7 )
    C_ELM_POSOBJ_NLE( t_8, a_type2, 1 );
    C_ELM_POSOBJ_NLE( t_9, a_type3, 1 );
    C_ELM_POSOBJ_NLE( t_10, a_type4, 1 );
    t_6 = CALL_4ARGS( t_7, a_flags1, t_8, t_9, t_10 );
-   CHECK_FUNC_RESULT( t_6 );
-   CHECK_BOOL( t_6 );
+   CHECK_FUNC_RESULT( t_6 )
+   CHECK_BOOL( t_6 )
    t_5 = (Obj)(UInt)(t_6 != False);
    t_3 = t_5;
   }
@@ -4132,11 +4132,11 @@ and methods[8 * (i - 1) + 1]( flags1, type2![1], type3![1], type4![1] ) then */
    if ( t_3 ) {
     
     /* return methods[8 * (i - 1) + 6]; */
-    C_DIFF_INTOBJS( t_6, l_i, INTOBJ_INT(1) );
-    C_PROD_FIA( t_5, INTOBJ_INT(8), t_6 );
-    C_SUM_FIA( t_4, t_5, INTOBJ_INT(6) );
-    CHECK_INT_POS( t_4 );
-    C_ELM_LIST_FPL( t_3, l_methods, t_4 );
+    C_DIFF_INTOBJS( t_6, l_i, INTOBJ_INT(1) )
+    C_PROD_FIA( t_5, INTOBJ_INT(8), t_6 )
+    C_SUM_FIA( t_4, t_5, INTOBJ_INT(6) )
+    CHECK_INT_POS( t_4 )
+    C_ELM_LIST_FPL( t_3, l_methods, t_4 )
     RES_BRK_CURR_STAT();
     SWITCH_TO_OLD_FRAME(oldFrame);
     return t_3;
@@ -4147,7 +4147,7 @@ and methods[8 * (i - 1) + 1]( flags1, type2![1], type3![1], type4![1] ) then */
    else {
     
     /* j := j + 1; */
-    C_SUM_FIA( t_3, l_j, INTOBJ_INT(1) );
+    C_SUM_FIA( t_3, l_j, INTOBJ_INT(1) )
     l_j = t_3;
     
    }
@@ -4161,7 +4161,7 @@ and methods[8 * (i - 1) + 1]( flags1, type2![1], type3![1], type4![1] ) then */
  
  /* return fail; */
  t_1 = GC_fail;
- CHECK_BOUND( t_1, "fail" );
+ CHECK_BOUND( t_1, "fail" )
  RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
@@ -4205,7 +4205,7 @@ static Obj  HdlrFunc32 (
  Obj t_16 = 0;
  Bag oldFrame;
  OLD_BRK_CURR_STAT
- CHECK_NR_ARGS( 7, args );
+ CHECK_NR_ARGS( 7, args )
  a_operation = ELM_PLIST( args, 1 );
  a_k = ELM_PLIST( args, 2 );
  a_flags1 = ELM_PLIST( args, 3 );
@@ -4222,7 +4222,7 @@ static Obj  HdlrFunc32 (
  /* methods := METHODS_OPERATION( operation, 5 ); */
  t_2 = GF_METHODS__OPERATION;
  t_1 = CALL_2ARGS( t_2, a_operation, INTOBJ_INT(5) );
- CHECK_FUNC_RESULT( t_1 );
+ CHECK_FUNC_RESULT( t_1 )
  l_methods = t_1;
  
  /* j := 0; */
@@ -4231,9 +4231,9 @@ static Obj  HdlrFunc32 (
  /* for i in [ 1 .. LEN_LIST( methods ) / 9 ] do */
  t_4 = GF_LEN__LIST;
  t_3 = CALL_1ARGS( t_4, l_methods );
- CHECK_FUNC_RESULT( t_3 );
+ CHECK_FUNC_RESULT( t_3 )
  t_2 = QUO( t_3, INTOBJ_INT(9) );
- CHECK_INT_SMALL( t_2 );
+ CHECK_INT_SMALL( t_2 )
  for ( t_1 = INTOBJ_INT(1);
        ((Int)t_1) <= ((Int)t_2);
        t_1 = (Obj)(((UInt)t_1)+4) ) {
@@ -4242,27 +4242,27 @@ static Obj  HdlrFunc32 (
   /* if IS_SUBSET_FLAGS( methods[9 * (i - 1) + 2], flags1 ) and IS_SUBSET_FLAGS( type2![2], methods[9 * (i - 1) + 3] ) and IS_SUBSET_FLAGS( type3![2], methods[9 * (i - 1) + 4] ) and IS_SUBSET_FLAGS( type4![2], methods[9 * (i - 1) + 5] ) 
   and IS_SUBSET_FLAGS( type5![2], methods[9 * (i - 1) + 6] ) and methods[9 * (i - 1) + 1]( flags1, type2![1], type3![1], type4![1], type5![1] ) then */
   t_10 = GF_IS__SUBSET__FLAGS;
-  C_DIFF_INTOBJS( t_14, l_i, INTOBJ_INT(1) );
-  C_PROD_FIA( t_13, INTOBJ_INT(9), t_14 );
-  C_SUM_FIA( t_12, t_13, INTOBJ_INT(2) );
-  CHECK_INT_POS( t_12 );
-  C_ELM_LIST_FPL( t_11, l_methods, t_12 );
+  C_DIFF_INTOBJS( t_14, l_i, INTOBJ_INT(1) )
+  C_PROD_FIA( t_13, INTOBJ_INT(9), t_14 )
+  C_SUM_FIA( t_12, t_13, INTOBJ_INT(2) )
+  CHECK_INT_POS( t_12 )
+  C_ELM_LIST_FPL( t_11, l_methods, t_12 )
   t_9 = CALL_2ARGS( t_10, t_11, a_flags1 );
-  CHECK_FUNC_RESULT( t_9 );
-  CHECK_BOOL( t_9 );
+  CHECK_FUNC_RESULT( t_9 )
+  CHECK_BOOL( t_9 )
   t_8 = (Obj)(UInt)(t_9 != False);
   t_7 = t_8;
   if ( t_7 ) {
    t_11 = GF_IS__SUBSET__FLAGS;
    C_ELM_POSOBJ_NLE( t_12, a_type2, 2 );
-   C_DIFF_INTOBJS( t_16, l_i, INTOBJ_INT(1) );
-   C_PROD_FIA( t_15, INTOBJ_INT(9), t_16 );
-   C_SUM_FIA( t_14, t_15, INTOBJ_INT(3) );
-   CHECK_INT_POS( t_14 );
-   C_ELM_LIST_FPL( t_13, l_methods, t_14 );
+   C_DIFF_INTOBJS( t_16, l_i, INTOBJ_INT(1) )
+   C_PROD_FIA( t_15, INTOBJ_INT(9), t_16 )
+   C_SUM_FIA( t_14, t_15, INTOBJ_INT(3) )
+   CHECK_INT_POS( t_14 )
+   C_ELM_LIST_FPL( t_13, l_methods, t_14 )
    t_10 = CALL_2ARGS( t_11, t_12, t_13 );
-   CHECK_FUNC_RESULT( t_10 );
-   CHECK_BOOL( t_10 );
+   CHECK_FUNC_RESULT( t_10 )
+   CHECK_BOOL( t_10 )
    t_9 = (Obj)(UInt)(t_10 != False);
    t_7 = t_9;
   }
@@ -4270,14 +4270,14 @@ static Obj  HdlrFunc32 (
   if ( t_6 ) {
    t_10 = GF_IS__SUBSET__FLAGS;
    C_ELM_POSOBJ_NLE( t_11, a_type3, 2 );
-   C_DIFF_INTOBJS( t_15, l_i, INTOBJ_INT(1) );
-   C_PROD_FIA( t_14, INTOBJ_INT(9), t_15 );
-   C_SUM_FIA( t_13, t_14, INTOBJ_INT(4) );
-   CHECK_INT_POS( t_13 );
-   C_ELM_LIST_FPL( t_12, l_methods, t_13 );
+   C_DIFF_INTOBJS( t_15, l_i, INTOBJ_INT(1) )
+   C_PROD_FIA( t_14, INTOBJ_INT(9), t_15 )
+   C_SUM_FIA( t_13, t_14, INTOBJ_INT(4) )
+   CHECK_INT_POS( t_13 )
+   C_ELM_LIST_FPL( t_12, l_methods, t_13 )
    t_9 = CALL_2ARGS( t_10, t_11, t_12 );
-   CHECK_FUNC_RESULT( t_9 );
-   CHECK_BOOL( t_9 );
+   CHECK_FUNC_RESULT( t_9 )
+   CHECK_BOOL( t_9 )
    t_8 = (Obj)(UInt)(t_9 != False);
    t_6 = t_8;
   }
@@ -4285,14 +4285,14 @@ static Obj  HdlrFunc32 (
   if ( t_5 ) {
    t_9 = GF_IS__SUBSET__FLAGS;
    C_ELM_POSOBJ_NLE( t_10, a_type4, 2 );
-   C_DIFF_INTOBJS( t_14, l_i, INTOBJ_INT(1) );
-   C_PROD_FIA( t_13, INTOBJ_INT(9), t_14 );
-   C_SUM_FIA( t_12, t_13, INTOBJ_INT(5) );
-   CHECK_INT_POS( t_12 );
-   C_ELM_LIST_FPL( t_11, l_methods, t_12 );
+   C_DIFF_INTOBJS( t_14, l_i, INTOBJ_INT(1) )
+   C_PROD_FIA( t_13, INTOBJ_INT(9), t_14 )
+   C_SUM_FIA( t_12, t_13, INTOBJ_INT(5) )
+   CHECK_INT_POS( t_12 )
+   C_ELM_LIST_FPL( t_11, l_methods, t_12 )
    t_8 = CALL_2ARGS( t_9, t_10, t_11 );
-   CHECK_FUNC_RESULT( t_8 );
-   CHECK_BOOL( t_8 );
+   CHECK_FUNC_RESULT( t_8 )
+   CHECK_BOOL( t_8 )
    t_7 = (Obj)(UInt)(t_8 != False);
    t_5 = t_7;
   }
@@ -4300,32 +4300,32 @@ static Obj  HdlrFunc32 (
   if ( t_4 ) {
    t_8 = GF_IS__SUBSET__FLAGS;
    C_ELM_POSOBJ_NLE( t_9, a_type5, 2 );
-   C_DIFF_INTOBJS( t_13, l_i, INTOBJ_INT(1) );
-   C_PROD_FIA( t_12, INTOBJ_INT(9), t_13 );
-   C_SUM_FIA( t_11, t_12, INTOBJ_INT(6) );
-   CHECK_INT_POS( t_11 );
-   C_ELM_LIST_FPL( t_10, l_methods, t_11 );
+   C_DIFF_INTOBJS( t_13, l_i, INTOBJ_INT(1) )
+   C_PROD_FIA( t_12, INTOBJ_INT(9), t_13 )
+   C_SUM_FIA( t_11, t_12, INTOBJ_INT(6) )
+   CHECK_INT_POS( t_11 )
+   C_ELM_LIST_FPL( t_10, l_methods, t_11 )
    t_7 = CALL_2ARGS( t_8, t_9, t_10 );
-   CHECK_FUNC_RESULT( t_7 );
-   CHECK_BOOL( t_7 );
+   CHECK_FUNC_RESULT( t_7 )
+   CHECK_BOOL( t_7 )
    t_6 = (Obj)(UInt)(t_7 != False);
    t_4 = t_6;
   }
   t_3 = t_4;
   if ( t_3 ) {
-   C_DIFF_INTOBJS( t_10, l_i, INTOBJ_INT(1) );
-   C_PROD_FIA( t_9, INTOBJ_INT(9), t_10 );
-   C_SUM_FIA( t_8, t_9, INTOBJ_INT(1) );
-   CHECK_INT_POS( t_8 );
-   C_ELM_LIST_FPL( t_7, l_methods, t_8 );
-   CHECK_FUNC( t_7 );
+   C_DIFF_INTOBJS( t_10, l_i, INTOBJ_INT(1) )
+   C_PROD_FIA( t_9, INTOBJ_INT(9), t_10 )
+   C_SUM_FIA( t_8, t_9, INTOBJ_INT(1) )
+   CHECK_INT_POS( t_8 )
+   C_ELM_LIST_FPL( t_7, l_methods, t_8 )
+   CHECK_FUNC( t_7 )
    C_ELM_POSOBJ_NLE( t_8, a_type2, 1 );
    C_ELM_POSOBJ_NLE( t_9, a_type3, 1 );
    C_ELM_POSOBJ_NLE( t_10, a_type4, 1 );
    C_ELM_POSOBJ_NLE( t_11, a_type5, 1 );
    t_6 = CALL_5ARGS( t_7, a_flags1, t_8, t_9, t_10, t_11 );
-   CHECK_FUNC_RESULT( t_6 );
-   CHECK_BOOL( t_6 );
+   CHECK_FUNC_RESULT( t_6 )
+   CHECK_BOOL( t_6 )
    t_5 = (Obj)(UInt)(t_6 != False);
    t_3 = t_5;
   }
@@ -4336,11 +4336,11 @@ static Obj  HdlrFunc32 (
    if ( t_3 ) {
     
     /* return methods[9 * (i - 1) + 7]; */
-    C_DIFF_INTOBJS( t_6, l_i, INTOBJ_INT(1) );
-    C_PROD_FIA( t_5, INTOBJ_INT(9), t_6 );
-    C_SUM_FIA( t_4, t_5, INTOBJ_INT(7) );
-    CHECK_INT_POS( t_4 );
-    C_ELM_LIST_FPL( t_3, l_methods, t_4 );
+    C_DIFF_INTOBJS( t_6, l_i, INTOBJ_INT(1) )
+    C_PROD_FIA( t_5, INTOBJ_INT(9), t_6 )
+    C_SUM_FIA( t_4, t_5, INTOBJ_INT(7) )
+    CHECK_INT_POS( t_4 )
+    C_ELM_LIST_FPL( t_3, l_methods, t_4 )
     RES_BRK_CURR_STAT();
     SWITCH_TO_OLD_FRAME(oldFrame);
     return t_3;
@@ -4351,7 +4351,7 @@ static Obj  HdlrFunc32 (
    else {
     
     /* j := j + 1; */
-    C_SUM_FIA( t_3, l_j, INTOBJ_INT(1) );
+    C_SUM_FIA( t_3, l_j, INTOBJ_INT(1) )
     l_j = t_3;
     
    }
@@ -4365,7 +4365,7 @@ static Obj  HdlrFunc32 (
  
  /* return fail; */
  t_1 = GC_fail;
- CHECK_BOUND( t_1, "fail" );
+ CHECK_BOUND( t_1, "fail" )
  RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
@@ -4411,7 +4411,7 @@ static Obj  HdlrFunc33 (
  Obj t_17 = 0;
  Bag oldFrame;
  OLD_BRK_CURR_STAT
- CHECK_NR_ARGS( 8, args );
+ CHECK_NR_ARGS( 8, args )
  a_operation = ELM_PLIST( args, 1 );
  a_k = ELM_PLIST( args, 2 );
  a_flags1 = ELM_PLIST( args, 3 );
@@ -4429,7 +4429,7 @@ static Obj  HdlrFunc33 (
  /* methods := METHODS_OPERATION( operation, 6 ); */
  t_2 = GF_METHODS__OPERATION;
  t_1 = CALL_2ARGS( t_2, a_operation, INTOBJ_INT(6) );
- CHECK_FUNC_RESULT( t_1 );
+ CHECK_FUNC_RESULT( t_1 )
  l_methods = t_1;
  
  /* j := 0; */
@@ -4438,9 +4438,9 @@ static Obj  HdlrFunc33 (
  /* for i in [ 1 .. LEN_LIST( methods ) / 10 ] do */
  t_4 = GF_LEN__LIST;
  t_3 = CALL_1ARGS( t_4, l_methods );
- CHECK_FUNC_RESULT( t_3 );
+ CHECK_FUNC_RESULT( t_3 )
  t_2 = QUO( t_3, INTOBJ_INT(10) );
- CHECK_INT_SMALL( t_2 );
+ CHECK_INT_SMALL( t_2 )
  for ( t_1 = INTOBJ_INT(1);
        ((Int)t_1) <= ((Int)t_2);
        t_1 = (Obj)(((UInt)t_1)+4) ) {
@@ -4449,27 +4449,27 @@ static Obj  HdlrFunc33 (
   /* if IS_SUBSET_FLAGS( methods[10 * (i - 1) + 2], flags1 ) and IS_SUBSET_FLAGS( type2![2], methods[10 * (i - 1) + 3] ) and IS_SUBSET_FLAGS( type3![2], methods[10 * (i - 1) + 4] ) and IS_SUBSET_FLAGS( type4![2], methods[10 * (i - 1) + 5] ) 
     and IS_SUBSET_FLAGS( type5![2], methods[10 * (i - 1) + 6] ) and IS_SUBSET_FLAGS( type6![2], methods[10 * (i - 1) + 7] ) and methods[10 * (i - 1) + 1]( flags1, type2![1], type3![1], type4![1], type5![1], type6![1] ) then */
   t_11 = GF_IS__SUBSET__FLAGS;
-  C_DIFF_INTOBJS( t_15, l_i, INTOBJ_INT(1) );
-  C_PROD_FIA( t_14, INTOBJ_INT(10), t_15 );
-  C_SUM_FIA( t_13, t_14, INTOBJ_INT(2) );
-  CHECK_INT_POS( t_13 );
-  C_ELM_LIST_FPL( t_12, l_methods, t_13 );
+  C_DIFF_INTOBJS( t_15, l_i, INTOBJ_INT(1) )
+  C_PROD_FIA( t_14, INTOBJ_INT(10), t_15 )
+  C_SUM_FIA( t_13, t_14, INTOBJ_INT(2) )
+  CHECK_INT_POS( t_13 )
+  C_ELM_LIST_FPL( t_12, l_methods, t_13 )
   t_10 = CALL_2ARGS( t_11, t_12, a_flags1 );
-  CHECK_FUNC_RESULT( t_10 );
-  CHECK_BOOL( t_10 );
+  CHECK_FUNC_RESULT( t_10 )
+  CHECK_BOOL( t_10 )
   t_9 = (Obj)(UInt)(t_10 != False);
   t_8 = t_9;
   if ( t_8 ) {
    t_12 = GF_IS__SUBSET__FLAGS;
    C_ELM_POSOBJ_NLE( t_13, a_type2, 2 );
-   C_DIFF_INTOBJS( t_17, l_i, INTOBJ_INT(1) );
-   C_PROD_FIA( t_16, INTOBJ_INT(10), t_17 );
-   C_SUM_FIA( t_15, t_16, INTOBJ_INT(3) );
-   CHECK_INT_POS( t_15 );
-   C_ELM_LIST_FPL( t_14, l_methods, t_15 );
+   C_DIFF_INTOBJS( t_17, l_i, INTOBJ_INT(1) )
+   C_PROD_FIA( t_16, INTOBJ_INT(10), t_17 )
+   C_SUM_FIA( t_15, t_16, INTOBJ_INT(3) )
+   CHECK_INT_POS( t_15 )
+   C_ELM_LIST_FPL( t_14, l_methods, t_15 )
    t_11 = CALL_2ARGS( t_12, t_13, t_14 );
-   CHECK_FUNC_RESULT( t_11 );
-   CHECK_BOOL( t_11 );
+   CHECK_FUNC_RESULT( t_11 )
+   CHECK_BOOL( t_11 )
    t_10 = (Obj)(UInt)(t_11 != False);
    t_8 = t_10;
   }
@@ -4477,14 +4477,14 @@ static Obj  HdlrFunc33 (
   if ( t_7 ) {
    t_11 = GF_IS__SUBSET__FLAGS;
    C_ELM_POSOBJ_NLE( t_12, a_type3, 2 );
-   C_DIFF_INTOBJS( t_16, l_i, INTOBJ_INT(1) );
-   C_PROD_FIA( t_15, INTOBJ_INT(10), t_16 );
-   C_SUM_FIA( t_14, t_15, INTOBJ_INT(4) );
-   CHECK_INT_POS( t_14 );
-   C_ELM_LIST_FPL( t_13, l_methods, t_14 );
+   C_DIFF_INTOBJS( t_16, l_i, INTOBJ_INT(1) )
+   C_PROD_FIA( t_15, INTOBJ_INT(10), t_16 )
+   C_SUM_FIA( t_14, t_15, INTOBJ_INT(4) )
+   CHECK_INT_POS( t_14 )
+   C_ELM_LIST_FPL( t_13, l_methods, t_14 )
    t_10 = CALL_2ARGS( t_11, t_12, t_13 );
-   CHECK_FUNC_RESULT( t_10 );
-   CHECK_BOOL( t_10 );
+   CHECK_FUNC_RESULT( t_10 )
+   CHECK_BOOL( t_10 )
    t_9 = (Obj)(UInt)(t_10 != False);
    t_7 = t_9;
   }
@@ -4492,14 +4492,14 @@ static Obj  HdlrFunc33 (
   if ( t_6 ) {
    t_10 = GF_IS__SUBSET__FLAGS;
    C_ELM_POSOBJ_NLE( t_11, a_type4, 2 );
-   C_DIFF_INTOBJS( t_15, l_i, INTOBJ_INT(1) );
-   C_PROD_FIA( t_14, INTOBJ_INT(10), t_15 );
-   C_SUM_FIA( t_13, t_14, INTOBJ_INT(5) );
-   CHECK_INT_POS( t_13 );
-   C_ELM_LIST_FPL( t_12, l_methods, t_13 );
+   C_DIFF_INTOBJS( t_15, l_i, INTOBJ_INT(1) )
+   C_PROD_FIA( t_14, INTOBJ_INT(10), t_15 )
+   C_SUM_FIA( t_13, t_14, INTOBJ_INT(5) )
+   CHECK_INT_POS( t_13 )
+   C_ELM_LIST_FPL( t_12, l_methods, t_13 )
    t_9 = CALL_2ARGS( t_10, t_11, t_12 );
-   CHECK_FUNC_RESULT( t_9 );
-   CHECK_BOOL( t_9 );
+   CHECK_FUNC_RESULT( t_9 )
+   CHECK_BOOL( t_9 )
    t_8 = (Obj)(UInt)(t_9 != False);
    t_6 = t_8;
   }
@@ -4507,14 +4507,14 @@ static Obj  HdlrFunc33 (
   if ( t_5 ) {
    t_9 = GF_IS__SUBSET__FLAGS;
    C_ELM_POSOBJ_NLE( t_10, a_type5, 2 );
-   C_DIFF_INTOBJS( t_14, l_i, INTOBJ_INT(1) );
-   C_PROD_FIA( t_13, INTOBJ_INT(10), t_14 );
-   C_SUM_FIA( t_12, t_13, INTOBJ_INT(6) );
-   CHECK_INT_POS( t_12 );
-   C_ELM_LIST_FPL( t_11, l_methods, t_12 );
+   C_DIFF_INTOBJS( t_14, l_i, INTOBJ_INT(1) )
+   C_PROD_FIA( t_13, INTOBJ_INT(10), t_14 )
+   C_SUM_FIA( t_12, t_13, INTOBJ_INT(6) )
+   CHECK_INT_POS( t_12 )
+   C_ELM_LIST_FPL( t_11, l_methods, t_12 )
    t_8 = CALL_2ARGS( t_9, t_10, t_11 );
-   CHECK_FUNC_RESULT( t_8 );
-   CHECK_BOOL( t_8 );
+   CHECK_FUNC_RESULT( t_8 )
+   CHECK_BOOL( t_8 )
    t_7 = (Obj)(UInt)(t_8 != False);
    t_5 = t_7;
   }
@@ -4522,33 +4522,33 @@ static Obj  HdlrFunc33 (
   if ( t_4 ) {
    t_8 = GF_IS__SUBSET__FLAGS;
    C_ELM_POSOBJ_NLE( t_9, a_type6, 2 );
-   C_DIFF_INTOBJS( t_13, l_i, INTOBJ_INT(1) );
-   C_PROD_FIA( t_12, INTOBJ_INT(10), t_13 );
-   C_SUM_FIA( t_11, t_12, INTOBJ_INT(7) );
-   CHECK_INT_POS( t_11 );
-   C_ELM_LIST_FPL( t_10, l_methods, t_11 );
+   C_DIFF_INTOBJS( t_13, l_i, INTOBJ_INT(1) )
+   C_PROD_FIA( t_12, INTOBJ_INT(10), t_13 )
+   C_SUM_FIA( t_11, t_12, INTOBJ_INT(7) )
+   CHECK_INT_POS( t_11 )
+   C_ELM_LIST_FPL( t_10, l_methods, t_11 )
    t_7 = CALL_2ARGS( t_8, t_9, t_10 );
-   CHECK_FUNC_RESULT( t_7 );
-   CHECK_BOOL( t_7 );
+   CHECK_FUNC_RESULT( t_7 )
+   CHECK_BOOL( t_7 )
    t_6 = (Obj)(UInt)(t_7 != False);
    t_4 = t_6;
   }
   t_3 = t_4;
   if ( t_3 ) {
-   C_DIFF_INTOBJS( t_10, l_i, INTOBJ_INT(1) );
-   C_PROD_FIA( t_9, INTOBJ_INT(10), t_10 );
-   C_SUM_FIA( t_8, t_9, INTOBJ_INT(1) );
-   CHECK_INT_POS( t_8 );
-   C_ELM_LIST_FPL( t_7, l_methods, t_8 );
-   CHECK_FUNC( t_7 );
+   C_DIFF_INTOBJS( t_10, l_i, INTOBJ_INT(1) )
+   C_PROD_FIA( t_9, INTOBJ_INT(10), t_10 )
+   C_SUM_FIA( t_8, t_9, INTOBJ_INT(1) )
+   CHECK_INT_POS( t_8 )
+   C_ELM_LIST_FPL( t_7, l_methods, t_8 )
+   CHECK_FUNC( t_7 )
    C_ELM_POSOBJ_NLE( t_8, a_type2, 1 );
    C_ELM_POSOBJ_NLE( t_9, a_type3, 1 );
    C_ELM_POSOBJ_NLE( t_10, a_type4, 1 );
    C_ELM_POSOBJ_NLE( t_11, a_type5, 1 );
    C_ELM_POSOBJ_NLE( t_12, a_type6, 1 );
    t_6 = CALL_6ARGS( t_7, a_flags1, t_8, t_9, t_10, t_11, t_12 );
-   CHECK_FUNC_RESULT( t_6 );
-   CHECK_BOOL( t_6 );
+   CHECK_FUNC_RESULT( t_6 )
+   CHECK_BOOL( t_6 )
    t_5 = (Obj)(UInt)(t_6 != False);
    t_3 = t_5;
   }
@@ -4559,11 +4559,11 @@ static Obj  HdlrFunc33 (
    if ( t_3 ) {
     
     /* return methods[10 * (i - 1) + 8]; */
-    C_DIFF_INTOBJS( t_6, l_i, INTOBJ_INT(1) );
-    C_PROD_FIA( t_5, INTOBJ_INT(10), t_6 );
-    C_SUM_FIA( t_4, t_5, INTOBJ_INT(8) );
-    CHECK_INT_POS( t_4 );
-    C_ELM_LIST_FPL( t_3, l_methods, t_4 );
+    C_DIFF_INTOBJS( t_6, l_i, INTOBJ_INT(1) )
+    C_PROD_FIA( t_5, INTOBJ_INT(10), t_6 )
+    C_SUM_FIA( t_4, t_5, INTOBJ_INT(8) )
+    CHECK_INT_POS( t_4 )
+    C_ELM_LIST_FPL( t_3, l_methods, t_4 )
     RES_BRK_CURR_STAT();
     SWITCH_TO_OLD_FRAME(oldFrame);
     return t_3;
@@ -4574,7 +4574,7 @@ static Obj  HdlrFunc33 (
    else {
     
     /* j := j + 1; */
-    C_SUM_FIA( t_3, l_j, INTOBJ_INT(1) );
+    C_SUM_FIA( t_3, l_j, INTOBJ_INT(1) )
     l_j = t_3;
     
    }
@@ -4588,7 +4588,7 @@ static Obj  HdlrFunc33 (
  
  /* return fail; */
  t_1 = GC_fail;
- CHECK_BOUND( t_1, "fail" );
+ CHECK_BOUND( t_1, "fail" )
  RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;

--- a/src/c_oper1.c
+++ b/src/c_oper1.c
@@ -201,8 +201,8 @@ static Obj  HdlrFunc2 (
  
  /* if IGNORE_IMMEDIATE_METHODS then */
  t_2 = GC_IGNORE__IMMEDIATE__METHODS;
- CHECK_BOUND( t_2, "IGNORE_IMMEDIATE_METHODS" );
- CHECK_BOOL( t_2 );
+ CHECK_BOUND( t_2, "IGNORE_IMMEDIATE_METHODS" )
+ CHECK_BOOL( t_2 )
  t_1 = (Obj)(UInt)(t_2 != False);
  if ( t_1 ) {
   
@@ -217,10 +217,10 @@ static Obj  HdlrFunc2 (
  /* if IS_SUBSET_FLAGS( IMM_FLAGS, flags ) then */
  t_3 = GF_IS__SUBSET__FLAGS;
  t_4 = GC_IMM__FLAGS;
- CHECK_BOUND( t_4, "IMM_FLAGS" );
+ CHECK_BOUND( t_4, "IMM_FLAGS" )
  t_2 = CALL_2ARGS( t_3, t_4, a_flags );
- CHECK_FUNC_RESULT( t_2 );
- CHECK_BOOL( t_2 );
+ CHECK_FUNC_RESULT( t_2 )
+ CHECK_BOOL( t_2 )
  t_1 = (Obj)(UInt)(t_2 != False);
  if ( t_1 ) {
   
@@ -235,18 +235,18 @@ static Obj  HdlrFunc2 (
  /* flags := SUB_FLAGS( flags, IMM_FLAGS ); */
  t_2 = GF_SUB__FLAGS;
  t_3 = GC_IMM__FLAGS;
- CHECK_BOUND( t_3, "IMM_FLAGS" );
+ CHECK_BOUND( t_3, "IMM_FLAGS" )
  t_1 = CALL_2ARGS( t_2, a_flags, t_3 );
- CHECK_FUNC_RESULT( t_1 );
+ CHECK_FUNC_RESULT( t_1 )
  a_flags = t_1;
  
  /* flagspos := SHALLOW_COPY_OBJ( TRUES_FLAGS( flags ) ); */
  t_2 = GF_SHALLOW__COPY__OBJ;
  t_4 = GF_TRUES__FLAGS;
  t_3 = CALL_1ARGS( t_4, a_flags );
- CHECK_FUNC_RESULT( t_3 );
+ CHECK_FUNC_RESULT( t_3 )
  t_1 = CALL_1ARGS( t_2, t_3 );
- CHECK_FUNC_RESULT( t_1 );
+ CHECK_FUNC_RESULT( t_1 )
  l_flagspos = t_1;
  
  /* tried := [  ]; */
@@ -257,7 +257,7 @@ static Obj  HdlrFunc2 (
  /* type := TYPE_OBJ( obj ); */
  t_2 = GF_TYPE__OBJ;
  t_1 = CALL_1ARGS( t_2, a_obj );
- CHECK_FUNC_RESULT( t_1 );
+ CHECK_FUNC_RESULT( t_1 )
  l_type = t_1;
  
  /* flags := type![2]; */
@@ -289,23 +289,23 @@ static Obj  HdlrFunc2 (
   
   /* if IsBound( IMMEDIATES[j] ) then */
   t_7 = GC_IMMEDIATES;
-  CHECK_BOUND( t_7, "IMMEDIATES" );
-  CHECK_INT_POS( l_j );
+  CHECK_BOUND( t_7, "IMMEDIATES" )
+  CHECK_INT_POS( l_j )
   t_6 = C_ISB_LIST( t_7, l_j );
   t_5 = (Obj)(UInt)(t_6 != False);
   if ( t_5 ) {
    
    /* imm := IMMEDIATES[j]; */
    t_6 = GC_IMMEDIATES;
-   CHECK_BOUND( t_6, "IMMEDIATES" );
-   C_ELM_LIST_FPL( t_5, t_6, l_j );
+   CHECK_BOUND( t_6, "IMMEDIATES" )
+   C_ELM_LIST_FPL( t_5, t_6, l_j )
    l_imm = t_5;
    
    /* for i in [ 0, 7 .. LEN_LIST( imm ) - 7 ] do */
    t_11 = GF_LEN__LIST;
    t_10 = CALL_1ARGS( t_11, l_imm );
-   CHECK_FUNC_RESULT( t_10 );
-   C_DIFF_FIA( t_9, t_10, INTOBJ_INT(7) );
+   CHECK_FUNC_RESULT( t_10 )
+   C_DIFF_FIA( t_9, t_10, INTOBJ_INT(7) )
    t_8 = Range3Check( INTOBJ_INT(0), INTOBJ_INT(7), t_9 );
    if ( IS_SMALL_LIST(t_8) ) {
     t_7 = (Obj)(UInt)1;
@@ -330,31 +330,31 @@ static Obj  HdlrFunc2 (
     
     /* if IS_SUBSET_FLAGS( flags, imm[i + 4] ) and not IS_SUBSET_FLAGS( flags, imm[i + 3] ) and not imm[i + 6] in tried then */
     t_13 = GF_IS__SUBSET__FLAGS;
-    C_SUM_FIA( t_15, l_i, INTOBJ_INT(4) );
-    CHECK_INT_POS( t_15 );
-    C_ELM_LIST_FPL( t_14, l_imm, t_15 );
+    C_SUM_FIA( t_15, l_i, INTOBJ_INT(4) )
+    CHECK_INT_POS( t_15 )
+    C_ELM_LIST_FPL( t_14, l_imm, t_15 )
     t_12 = CALL_2ARGS( t_13, a_flags, t_14 );
-    CHECK_FUNC_RESULT( t_12 );
-    CHECK_BOOL( t_12 );
+    CHECK_FUNC_RESULT( t_12 )
+    CHECK_BOOL( t_12 )
     t_11 = (Obj)(UInt)(t_12 != False);
     t_10 = t_11;
     if ( t_10 ) {
      t_15 = GF_IS__SUBSET__FLAGS;
-     C_SUM_FIA( t_17, l_i, INTOBJ_INT(3) );
-     CHECK_INT_POS( t_17 );
-     C_ELM_LIST_FPL( t_16, l_imm, t_17 );
+     C_SUM_FIA( t_17, l_i, INTOBJ_INT(3) )
+     CHECK_INT_POS( t_17 )
+     C_ELM_LIST_FPL( t_16, l_imm, t_17 )
      t_14 = CALL_2ARGS( t_15, a_flags, t_16 );
-     CHECK_FUNC_RESULT( t_14 );
-     CHECK_BOOL( t_14 );
+     CHECK_FUNC_RESULT( t_14 )
+     CHECK_BOOL( t_14 )
      t_13 = (Obj)(UInt)(t_14 != False);
      t_12 = (Obj)(UInt)( ! ((Int)t_13) );
      t_10 = t_12;
     }
     t_9 = t_10;
     if ( t_9 ) {
-     C_SUM_FIA( t_14, l_i, INTOBJ_INT(6) );
-     CHECK_INT_POS( t_14 );
-     C_ELM_LIST_FPL( t_13, l_imm, t_14 );
+     C_SUM_FIA( t_14, l_i, INTOBJ_INT(6) )
+     CHECK_INT_POS( t_14 )
+     C_ELM_LIST_FPL( t_13, l_imm, t_14 )
      t_12 = (Obj)(UInt)(IN( t_13, l_tried ));
      t_11 = (Obj)(UInt)( ! ((Int)t_12) );
      t_9 = t_11;
@@ -363,41 +363,41 @@ static Obj  HdlrFunc2 (
      
      /* res := IMMEDIATE_METHODS[imm[i + 6]]( obj ); */
      t_11 = GC_IMMEDIATE__METHODS;
-     CHECK_BOUND( t_11, "IMMEDIATE_METHODS" );
-     C_SUM_FIA( t_13, l_i, INTOBJ_INT(6) );
-     CHECK_INT_POS( t_13 );
-     C_ELM_LIST_FPL( t_12, l_imm, t_13 );
-     CHECK_INT_POS( t_12 );
-     C_ELM_LIST_FPL( t_10, t_11, t_12 );
-     CHECK_FUNC( t_10 );
+     CHECK_BOUND( t_11, "IMMEDIATE_METHODS" )
+     C_SUM_FIA( t_13, l_i, INTOBJ_INT(6) )
+     CHECK_INT_POS( t_13 )
+     C_ELM_LIST_FPL( t_12, l_imm, t_13 )
+     CHECK_INT_POS( t_12 )
+     C_ELM_LIST_FPL( t_10, t_11, t_12 )
+     CHECK_FUNC( t_10 )
      t_9 = CALL_1ARGS( t_10, a_obj );
-     CHECK_FUNC_RESULT( t_9 );
+     CHECK_FUNC_RESULT( t_9 )
      l_res = t_9;
      
      /* ADD_LIST( tried, imm[i + 6] ); */
      t_9 = GF_ADD__LIST;
-     C_SUM_FIA( t_11, l_i, INTOBJ_INT(6) );
-     CHECK_INT_POS( t_11 );
-     C_ELM_LIST_FPL( t_10, l_imm, t_11 );
+     C_SUM_FIA( t_11, l_i, INTOBJ_INT(6) )
+     CHECK_INT_POS( t_11 )
+     C_ELM_LIST_FPL( t_10, l_imm, t_11 )
      CALL_2ARGS( t_9, l_tried, t_10 );
      
      /* RUN_IMMEDIATE_METHODS_CHECKS := RUN_IMMEDIATE_METHODS_CHECKS + 1; */
      t_10 = GC_RUN__IMMEDIATE__METHODS__CHECKS;
-     CHECK_BOUND( t_10, "RUN_IMMEDIATE_METHODS_CHECKS" );
-     C_SUM_FIA( t_9, t_10, INTOBJ_INT(1) );
+     CHECK_BOUND( t_10, "RUN_IMMEDIATE_METHODS_CHECKS" )
+     C_SUM_FIA( t_9, t_10, INTOBJ_INT(1) )
      AssGVar( G_RUN__IMMEDIATE__METHODS__CHECKS, t_9 );
      
      /* if TRACE_IMMEDIATE_METHODS then */
      t_10 = GC_TRACE__IMMEDIATE__METHODS;
-     CHECK_BOUND( t_10, "TRACE_IMMEDIATE_METHODS" );
-     CHECK_BOOL( t_10 );
+     CHECK_BOUND( t_10, "TRACE_IMMEDIATE_METHODS" )
+     CHECK_BOOL( t_10 )
      t_9 = (Obj)(UInt)(t_10 != False);
      if ( t_9 ) {
       
       /* if imm[i + 7] = false then */
-      C_SUM_FIA( t_11, l_i, INTOBJ_INT(7) );
-      CHECK_INT_POS( t_11 );
-      C_ELM_LIST_FPL( t_10, l_imm, t_11 );
+      C_SUM_FIA( t_11, l_i, INTOBJ_INT(7) )
+      CHECK_INT_POS( t_11 )
+      C_ELM_LIST_FPL( t_10, l_imm, t_11 )
       t_11 = False;
       t_9 = (Obj)(UInt)(EQ( t_10, t_11 ));
       if ( t_9 ) {
@@ -406,11 +406,11 @@ static Obj  HdlrFunc2 (
        t_9 = GF_Print;
        C_NEW_STRING( t_10, 15, "#I  immediate: " );
        t_12 = GF_NAME__FUNC;
-       C_SUM_FIA( t_14, l_i, INTOBJ_INT(1) );
-       CHECK_INT_POS( t_14 );
-       C_ELM_LIST_FPL( t_13, l_imm, t_14 );
+       C_SUM_FIA( t_14, l_i, INTOBJ_INT(1) )
+       CHECK_INT_POS( t_14 )
+       C_ELM_LIST_FPL( t_13, l_imm, t_14 )
        t_11 = CALL_1ARGS( t_12, t_13 );
-       CHECK_FUNC_RESULT( t_11 );
+       CHECK_FUNC_RESULT( t_11 )
        C_NEW_STRING( t_12, 1, "\n" );
        CALL_3ARGS( t_9, t_10, t_11, t_12 );
        
@@ -423,15 +423,15 @@ static Obj  HdlrFunc2 (
        t_9 = GF_Print;
        C_NEW_STRING( t_10, 15, "#I  immediate: " );
        t_12 = GF_NAME__FUNC;
-       C_SUM_FIA( t_14, l_i, INTOBJ_INT(1) );
-       CHECK_INT_POS( t_14 );
-       C_ELM_LIST_FPL( t_13, l_imm, t_14 );
+       C_SUM_FIA( t_14, l_i, INTOBJ_INT(1) )
+       CHECK_INT_POS( t_14 )
+       C_ELM_LIST_FPL( t_13, l_imm, t_14 )
        t_11 = CALL_1ARGS( t_12, t_13 );
-       CHECK_FUNC_RESULT( t_11 );
+       CHECK_FUNC_RESULT( t_11 )
        C_NEW_STRING( t_12, 2, ": " );
-       C_SUM_FIA( t_14, l_i, INTOBJ_INT(7) );
-       CHECK_INT_POS( t_14 );
-       C_ELM_LIST_FPL( t_13, l_imm, t_14 );
+       C_SUM_FIA( t_14, l_i, INTOBJ_INT(7) )
+       CHECK_INT_POS( t_14 )
+       C_ELM_LIST_FPL( t_13, l_imm, t_14 )
        C_NEW_STRING( t_14, 1, "\n" );
        CALL_5ARGS( t_9, t_10, t_11, t_12, t_13, t_14 );
        
@@ -443,7 +443,7 @@ static Obj  HdlrFunc2 (
      
      /* if res <> TRY_NEXT_METHOD then */
      t_10 = GC_TRY__NEXT__METHOD;
-     CHECK_BOUND( t_10, "TRY_NEXT_METHOD" );
+     CHECK_BOUND( t_10, "TRY_NEXT_METHOD" )
      t_9 = (Obj)(UInt)( ! EQ( l_res, t_10 ));
      if ( t_9 ) {
       
@@ -452,10 +452,10 @@ static Obj  HdlrFunc2 (
       AssGVar( G_IGNORE__IMMEDIATE__METHODS, t_9 );
       
       /* imm[i + 2]( obj, res ); */
-      C_SUM_FIA( t_10, l_i, INTOBJ_INT(2) );
-      CHECK_INT_POS( t_10 );
-      C_ELM_LIST_FPL( t_9, l_imm, t_10 );
-      CHECK_FUNC( t_9 );
+      C_SUM_FIA( t_10, l_i, INTOBJ_INT(2) )
+      CHECK_INT_POS( t_10 )
+      C_ELM_LIST_FPL( t_9, l_imm, t_10 )
+      CHECK_FUNC( t_9 )
       CALL_2ARGS( t_9, a_obj, l_res );
       
       /* IGNORE_IMMEDIATE_METHODS := false; */
@@ -464,18 +464,18 @@ static Obj  HdlrFunc2 (
       
       /* RUN_IMMEDIATE_METHODS_HITS := RUN_IMMEDIATE_METHODS_HITS + 1; */
       t_10 = GC_RUN__IMMEDIATE__METHODS__HITS;
-      CHECK_BOUND( t_10, "RUN_IMMEDIATE_METHODS_HITS" );
-      C_SUM_FIA( t_9, t_10, INTOBJ_INT(1) );
+      CHECK_BOUND( t_10, "RUN_IMMEDIATE_METHODS_HITS" )
+      C_SUM_FIA( t_9, t_10, INTOBJ_INT(1) )
       AssGVar( G_RUN__IMMEDIATE__METHODS__HITS, t_9 );
       
       /* if not IS_IDENTICAL_OBJ( TYPE_OBJ( obj ), type ) then */
       t_12 = GF_IS__IDENTICAL__OBJ;
       t_14 = GF_TYPE__OBJ;
       t_13 = CALL_1ARGS( t_14, a_obj );
-      CHECK_FUNC_RESULT( t_13 );
+      CHECK_FUNC_RESULT( t_13 )
       t_11 = CALL_2ARGS( t_12, t_13, l_type );
-      CHECK_FUNC_RESULT( t_11 );
-      CHECK_BOOL( t_11 );
+      CHECK_FUNC_RESULT( t_11 )
+      CHECK_BOOL( t_11 )
       t_10 = (Obj)(UInt)(t_11 != False);
       t_9 = (Obj)(UInt)( ! ((Int)t_10) );
       if ( t_9 ) {
@@ -483,29 +483,29 @@ static Obj  HdlrFunc2 (
        /* type := TYPE_OBJ( obj ); */
        t_10 = GF_TYPE__OBJ;
        t_9 = CALL_1ARGS( t_10, a_obj );
-       CHECK_FUNC_RESULT( t_9 );
+       CHECK_FUNC_RESULT( t_9 )
        l_type = t_9;
        
        /* newflags := SUB_FLAGS( type![2], IMM_FLAGS ); */
        t_10 = GF_SUB__FLAGS;
        C_ELM_POSOBJ_NLE( t_11, l_type, 2 );
        t_12 = GC_IMM__FLAGS;
-       CHECK_BOUND( t_12, "IMM_FLAGS" );
+       CHECK_BOUND( t_12, "IMM_FLAGS" )
        t_9 = CALL_2ARGS( t_10, t_11, t_12 );
-       CHECK_FUNC_RESULT( t_9 );
+       CHECK_FUNC_RESULT( t_9 )
        l_newflags = t_9;
        
        /* newflags := SUB_FLAGS( newflags, flags ); */
        t_10 = GF_SUB__FLAGS;
        t_9 = CALL_2ARGS( t_10, l_newflags, a_flags );
-       CHECK_FUNC_RESULT( t_9 );
+       CHECK_FUNC_RESULT( t_9 )
        l_newflags = t_9;
        
        /* APPEND_LIST_INTR( flagspos, TRUES_FLAGS( newflags ) ); */
        t_9 = GF_APPEND__LIST__INTR;
        t_11 = GF_TRUES__FLAGS;
        t_10 = CALL_1ARGS( t_11, l_newflags );
-       CHECK_FUNC_RESULT( t_10 );
+       CHECK_FUNC_RESULT( t_10 )
        CALL_2ARGS( t_9, l_flagspos, t_10 );
        
        /* flags := type![2]; */
@@ -578,24 +578,24 @@ static Obj  HdlrFunc3 (
  /* if IS_CONSTRUCTOR( opr ) then */
  t_3 = GF_IS__CONSTRUCTOR;
  t_2 = CALL_1ARGS( t_3, a_opr );
- CHECK_FUNC_RESULT( t_2 );
- CHECK_BOOL( t_2 );
+ CHECK_FUNC_RESULT( t_2 )
+ CHECK_BOOL( t_2 )
  t_1 = (Obj)(UInt)(t_2 != False);
  if ( t_1 ) {
   
   /* if 0 < LEN_LIST( flags ) then */
   t_3 = GF_LEN__LIST;
   t_2 = CALL_1ARGS( t_3, a_flags );
-  CHECK_FUNC_RESULT( t_2 );
+  CHECK_FUNC_RESULT( t_2 )
   t_1 = (Obj)(UInt)(LT( INTOBJ_INT(0), t_2 ));
   if ( t_1 ) {
    
    /* rank := rank - RankFilter( flags[1] ); */
    t_3 = GF_RankFilter;
-   C_ELM_LIST_FPL( t_4, a_flags, INTOBJ_INT(1) );
+   C_ELM_LIST_FPL( t_4, a_flags, INTOBJ_INT(1) )
    t_2 = CALL_1ARGS( t_3, t_4 );
-   CHECK_FUNC_RESULT( t_2 );
-   C_DIFF_FIA( t_1, a_rank, t_2 );
+   CHECK_FUNC_RESULT( t_2 )
+   C_DIFF_FIA( t_1, a_rank, t_2 )
    a_rank = t_1;
    
   }
@@ -632,8 +632,8 @@ static Obj  HdlrFunc3 (
    /* rank := rank + RankFilter( i ); */
    t_7 = GF_RankFilter;
    t_6 = CALL_1ARGS( t_7, l_i );
-   CHECK_FUNC_RESULT( t_6 );
-   C_SUM_FIA( t_5, a_rank, t_6 );
+   CHECK_FUNC_RESULT( t_6 )
+   C_SUM_FIA( t_5, a_rank, t_6 )
    a_rank = t_5;
    
   }
@@ -645,13 +645,13 @@ static Obj  HdlrFunc3 (
  /* narg := LEN_LIST( flags ); */
  t_2 = GF_LEN__LIST;
  t_1 = CALL_1ARGS( t_2, a_flags );
- CHECK_FUNC_RESULT( t_1 );
+ CHECK_FUNC_RESULT( t_1 )
  l_narg = t_1;
  
  /* methods := METHODS_OPERATION( opr, narg ); */
  t_2 = GF_METHODS__OPERATION;
  t_1 = CALL_2ARGS( t_2, a_opr, l_narg );
- CHECK_FUNC_RESULT( t_1 );
+ CHECK_FUNC_RESULT( t_1 )
  l_methods = t_1;
  
  /* if info = false then */
@@ -662,7 +662,7 @@ static Obj  HdlrFunc3 (
   /* info := NAME_FUNC( opr ); */
   t_2 = GF_NAME__FUNC;
   t_1 = CALL_1ARGS( t_2, a_opr );
-  CHECK_FUNC_RESULT( t_1 );
+  CHECK_FUNC_RESULT( t_1 )
   a_info = t_1;
   
  }
@@ -674,9 +674,9 @@ static Obj  HdlrFunc3 (
   t_2 = GF_SHALLOW__COPY__OBJ;
   t_4 = GF_NAME__FUNC;
   t_3 = CALL_1ARGS( t_4, a_opr );
-  CHECK_FUNC_RESULT( t_3 );
+  CHECK_FUNC_RESULT( t_3 )
   t_1 = CALL_1ARGS( t_2, t_3 );
-  CHECK_FUNC_RESULT( t_1 );
+  CHECK_FUNC_RESULT( t_1 )
   l_k = t_1;
   
   /* APPEND_LIST_INTR( k, ": " ); */
@@ -705,22 +705,22 @@ static Obj  HdlrFunc3 (
  while ( 1 ) {
   t_4 = GF_LEN__LIST;
   t_3 = CALL_1ARGS( t_4, l_methods );
-  CHECK_FUNC_RESULT( t_3 );
+  CHECK_FUNC_RESULT( t_3 )
   t_2 = (Obj)(UInt)(LT( l_i, t_3 ));
   t_1 = t_2;
   if ( t_1 ) {
-   C_SUM_FIA( t_6, l_narg, INTOBJ_INT(3) );
-   C_SUM_FIA( t_5, l_i, t_6 );
-   CHECK_INT_POS( t_5 );
-   C_ELM_LIST_FPL( t_4, l_methods, t_5 );
+   C_SUM_FIA( t_6, l_narg, INTOBJ_INT(3) )
+   C_SUM_FIA( t_5, l_i, t_6 )
+   CHECK_INT_POS( t_5 )
+   C_ELM_LIST_FPL( t_4, l_methods, t_5 )
    t_3 = (Obj)(UInt)(LT( a_rank, t_4 ));
    t_1 = t_3;
   }
   if ( ! t_1 ) break;
   
   /* i := i + (narg + 4); */
-  C_SUM_FIA( t_2, l_narg, INTOBJ_INT(4) );
-  C_SUM_FIA( t_1, l_i, t_2 );
+  C_SUM_FIA( t_2, l_narg, INTOBJ_INT(4) )
+  C_SUM_FIA( t_1, l_i, t_2 )
   l_i = t_1;
   
  }
@@ -732,8 +732,8 @@ static Obj  HdlrFunc3 (
  
  /* if REREADING then */
  t_2 = GC_REREADING;
- CHECK_BOUND( t_2, "REREADING" );
- CHECK_BOOL( t_2 );
+ CHECK_BOUND( t_2, "REREADING" )
+ CHECK_BOOL( t_2 )
  t_1 = (Obj)(UInt)(t_2 != False);
  if ( t_1 ) {
   
@@ -744,24 +744,24 @@ static Obj  HdlrFunc3 (
   while ( 1 ) {
    t_4 = GF_LEN__LIST;
    t_3 = CALL_1ARGS( t_4, l_methods );
-   CHECK_FUNC_RESULT( t_3 );
+   CHECK_FUNC_RESULT( t_3 )
    t_2 = (Obj)(UInt)(LT( l_k, t_3 ));
    t_1 = t_2;
    if ( t_1 ) {
-    C_SUM_FIA( t_6, l_k, l_narg );
-    C_SUM_FIA( t_5, t_6, INTOBJ_INT(3) );
-    CHECK_INT_POS( t_5 );
-    C_ELM_LIST_FPL( t_4, l_methods, t_5 );
+    C_SUM_FIA( t_6, l_k, l_narg )
+    C_SUM_FIA( t_5, t_6, INTOBJ_INT(3) )
+    CHECK_INT_POS( t_5 )
+    C_ELM_LIST_FPL( t_4, l_methods, t_5 )
     t_3 = (Obj)(UInt)(EQ( a_rank, t_4 ));
     t_1 = t_3;
    }
    if ( ! t_1 ) break;
    
    /* if info = methods[k + narg + 4] then */
-   C_SUM_FIA( t_4, l_k, l_narg );
-   C_SUM_FIA( t_3, t_4, INTOBJ_INT(4) );
-   CHECK_INT_POS( t_3 );
-   C_ELM_LIST_FPL( t_2, l_methods, t_3 );
+   C_SUM_FIA( t_4, l_k, l_narg )
+   C_SUM_FIA( t_3, t_4, INTOBJ_INT(4) )
+   CHECK_INT_POS( t_3 )
+   C_ELM_LIST_FPL( t_2, l_methods, t_3 )
    t_1 = (Obj)(UInt)(EQ( a_info, t_2 ));
    if ( t_1 ) {
     
@@ -770,7 +770,7 @@ static Obj  HdlrFunc3 (
     l_match = t_1;
     
     /* for j in [ 1 .. narg ] do */
-    CHECK_INT_SMALL( l_narg );
+    CHECK_INT_SMALL( l_narg )
     t_2 = l_narg;
     for ( t_1 = INTOBJ_INT(1);
           ((Int)t_1) <= ((Int)t_2);
@@ -782,23 +782,23 @@ static Obj  HdlrFunc3 (
       t_3 = l_match;
      }
      else if ( l_match == True ) {
-      C_SUM_FIA( t_7, l_k, l_j );
-      C_SUM_FIA( t_6, t_7, INTOBJ_INT(1) );
-      CHECK_INT_POS( t_6 );
-      C_ELM_LIST_FPL( t_5, l_methods, t_6 );
-      C_ELM_LIST_FPL( t_6, a_flags, l_j );
+      C_SUM_FIA( t_7, l_k, l_j )
+      C_SUM_FIA( t_6, t_7, INTOBJ_INT(1) )
+      CHECK_INT_POS( t_6 )
+      C_ELM_LIST_FPL( t_5, l_methods, t_6 )
+      C_ELM_LIST_FPL( t_6, a_flags, l_j )
       t_4 = (EQ( t_5, t_6 ) ? True : False);
       t_3 = t_4;
      }
      else {
-      CHECK_FUNC( l_match );
-      C_SUM_FIA( t_8, l_k, l_j );
-      C_SUM_FIA( t_7, t_8, INTOBJ_INT(1) );
-      CHECK_INT_POS( t_7 );
-      C_ELM_LIST_FPL( t_6, l_methods, t_7 );
-      C_ELM_LIST_FPL( t_7, a_flags, l_j );
+      CHECK_FUNC( l_match )
+      C_SUM_FIA( t_8, l_k, l_j )
+      C_SUM_FIA( t_7, t_8, INTOBJ_INT(1) )
+      CHECK_INT_POS( t_7 )
+      C_ELM_LIST_FPL( t_6, l_methods, t_7 )
+      C_ELM_LIST_FPL( t_7, a_flags, l_j )
       t_5 = (EQ( t_6, t_7 ) ? True : False);
-      CHECK_FUNC( t_5 );
+      CHECK_FUNC( t_5 )
       t_3 = NewAndFilter( l_match, t_5 );
      }
      l_match = t_3;
@@ -807,7 +807,7 @@ static Obj  HdlrFunc3 (
     /* od */
     
     /* if match then */
-    CHECK_BOOL( l_match );
+    CHECK_BOOL( l_match )
     t_1 = (Obj)(UInt)(l_match != False);
     if ( t_1 ) {
      
@@ -828,8 +828,8 @@ static Obj  HdlrFunc3 (
    /* fi */
    
    /* k := k + narg + 4; */
-   C_SUM_FIA( t_2, l_k, l_narg );
-   C_SUM_FIA( t_1, t_2, INTOBJ_INT(4) );
+   C_SUM_FIA( t_2, l_k, l_narg )
+   C_SUM_FIA( t_1, t_2, INTOBJ_INT(4) )
    l_k = t_1;
    
   }
@@ -840,8 +840,8 @@ static Obj  HdlrFunc3 (
  
  /* if not REREADING or not replace then */
  t_4 = GC_REREADING;
- CHECK_BOUND( t_4, "REREADING" );
- CHECK_BOOL( t_4 );
+ CHECK_BOUND( t_4, "REREADING" )
+ CHECK_BOOL( t_4 )
  t_3 = (Obj)(UInt)(t_4 != False);
  t_2 = (Obj)(UInt)( ! ((Int)t_3) );
  t_1 = t_2;
@@ -853,19 +853,19 @@ static Obj  HdlrFunc3 (
  if ( t_1 ) {
   
   /* methods{[ narg + 4 + i + 1 .. narg + 4 + LEN_LIST( methods ) ]} := methods{[ i + 1 .. LEN_LIST( methods ) ]}; */
-  C_SUM_FIA( t_4, l_narg, INTOBJ_INT(4) );
-  C_SUM_FIA( t_3, t_4, l_i );
-  C_SUM_FIA( t_2, t_3, INTOBJ_INT(1) );
-  C_SUM_FIA( t_4, l_narg, INTOBJ_INT(4) );
+  C_SUM_FIA( t_4, l_narg, INTOBJ_INT(4) )
+  C_SUM_FIA( t_3, t_4, l_i )
+  C_SUM_FIA( t_2, t_3, INTOBJ_INT(1) )
+  C_SUM_FIA( t_4, l_narg, INTOBJ_INT(4) )
   t_6 = GF_LEN__LIST;
   t_5 = CALL_1ARGS( t_6, l_methods );
-  CHECK_FUNC_RESULT( t_5 );
-  C_SUM_FIA( t_3, t_4, t_5 );
+  CHECK_FUNC_RESULT( t_5 )
+  C_SUM_FIA( t_3, t_4, t_5 )
   t_1 = Range2Check( t_2, t_3 );
-  C_SUM_FIA( t_4, l_i, INTOBJ_INT(1) );
+  C_SUM_FIA( t_4, l_i, INTOBJ_INT(1) )
   t_6 = GF_LEN__LIST;
   t_5 = CALL_1ARGS( t_6, l_methods );
-  CHECK_FUNC_RESULT( t_5 );
+  CHECK_FUNC_RESULT( t_5 )
   t_3 = Range2Check( t_4, t_5 );
   t_2 = ElmsListCheck( l_methods, t_3 );
   AsssListCheck( l_methods, t_1, t_2 );
@@ -879,11 +879,11 @@ static Obj  HdlrFunc3 (
  if ( t_1 ) {
   
   /* methods[i + 1] := RETURN_TRUE; */
-  C_SUM_FIA( t_1, l_i, INTOBJ_INT(1) );
-  CHECK_INT_POS( t_1 );
+  C_SUM_FIA( t_1, l_i, INTOBJ_INT(1) )
+  CHECK_INT_POS( t_1 )
   t_2 = GC_RETURN__TRUE;
-  CHECK_BOUND( t_2, "RETURN_TRUE" );
-  C_ASS_LIST_FPL( l_methods, t_1, t_2 );
+  CHECK_BOUND( t_2, "RETURN_TRUE" )
+  C_ASS_LIST_FPL( l_methods, t_1, t_2 )
   
  }
  
@@ -894,11 +894,11 @@ static Obj  HdlrFunc3 (
   if ( t_1 ) {
    
    /* methods[i + 1] := RETURN_FALSE; */
-   C_SUM_FIA( t_1, l_i, INTOBJ_INT(1) );
-   CHECK_INT_POS( t_1 );
+   C_SUM_FIA( t_1, l_i, INTOBJ_INT(1) )
+   CHECK_INT_POS( t_1 )
    t_2 = GC_RETURN__FALSE;
-   CHECK_BOUND( t_2, "RETURN_FALSE" );
-   C_ASS_LIST_FPL( l_methods, t_1, t_2 );
+   CHECK_BOUND( t_2, "RETURN_FALSE" )
+   C_ASS_LIST_FPL( l_methods, t_1, t_2 )
    
   }
   
@@ -906,29 +906,29 @@ static Obj  HdlrFunc3 (
   else {
    t_3 = GF_IS__FUNCTION;
    t_2 = CALL_1ARGS( t_3, a_rel );
-   CHECK_FUNC_RESULT( t_2 );
-   CHECK_BOOL( t_2 );
+   CHECK_FUNC_RESULT( t_2 )
+   CHECK_BOOL( t_2 )
    t_1 = (Obj)(UInt)(t_2 != False);
    if ( t_1 ) {
     
     /* if CHECK_INSTALL_METHOD then */
     t_2 = GC_CHECK__INSTALL__METHOD;
-    CHECK_BOUND( t_2, "CHECK_INSTALL_METHOD" );
-    CHECK_BOOL( t_2 );
+    CHECK_BOUND( t_2, "CHECK_INSTALL_METHOD" )
+    CHECK_BOOL( t_2 )
     t_1 = (Obj)(UInt)(t_2 != False);
     if ( t_1 ) {
      
      /* tmp := NARG_FUNC( rel ); */
      t_2 = GF_NARG__FUNC;
      t_1 = CALL_1ARGS( t_2, a_rel );
-     CHECK_FUNC_RESULT( t_1 );
+     CHECK_FUNC_RESULT( t_1 )
      l_tmp = t_1;
      
      /* if tmp < AINV( narg ) - 1 or tmp >= 0 and tmp <> narg then */
      t_5 = GF_AINV;
      t_4 = CALL_1ARGS( t_5, l_narg );
-     CHECK_FUNC_RESULT( t_4 );
-     C_DIFF_FIA( t_3, t_4, INTOBJ_INT(1) );
+     CHECK_FUNC_RESULT( t_4 )
+     C_DIFF_FIA( t_3, t_4, INTOBJ_INT(1) )
      t_2 = (Obj)(UInt)(LT( l_tmp, t_3 ));
      t_1 = t_2;
      if ( ! t_1 ) {
@@ -946,7 +946,7 @@ static Obj  HdlrFunc3 (
       t_1 = GF_Error;
       t_3 = GF_NAME__FUNC;
       t_2 = CALL_1ARGS( t_3, a_opr );
-      CHECK_FUNC_RESULT( t_2 );
+      CHECK_FUNC_RESULT( t_2 )
       C_NEW_STRING( t_3, 23, ": <famrel> must accept " );
       C_NEW_STRING( t_4, 10, " arguments" );
       CALL_4ARGS( t_1, t_2, t_3, l_narg, t_4 );
@@ -958,9 +958,9 @@ static Obj  HdlrFunc3 (
     /* fi */
     
     /* methods[i + 1] := rel; */
-    C_SUM_FIA( t_1, l_i, INTOBJ_INT(1) );
-    CHECK_INT_POS( t_1 );
-    C_ASS_LIST_FPL( l_methods, t_1, a_rel );
+    C_SUM_FIA( t_1, l_i, INTOBJ_INT(1) )
+    CHECK_INT_POS( t_1 )
+    C_ASS_LIST_FPL( l_methods, t_1, a_rel )
     
    }
    
@@ -971,7 +971,7 @@ static Obj  HdlrFunc3 (
     t_1 = GF_Error;
     t_3 = GF_NAME__FUNC;
     t_2 = CALL_1ARGS( t_3, a_opr );
-    CHECK_FUNC_RESULT( t_2 );
+    CHECK_FUNC_RESULT( t_2 )
     C_NEW_STRING( t_3, 49, ": <famrel> must be a function, `true', or `false'" );
     CALL_2ARGS( t_1, t_2, t_3 );
     
@@ -981,7 +981,7 @@ static Obj  HdlrFunc3 (
  /* fi */
  
  /* for k in [ 1 .. narg ] do */
- CHECK_INT_SMALL( l_narg );
+ CHECK_INT_SMALL( l_narg )
  t_2 = l_narg;
  for ( t_1 = INTOBJ_INT(1);
        ((Int)t_1) <= ((Int)t_2);
@@ -989,11 +989,11 @@ static Obj  HdlrFunc3 (
   l_k = t_1;
   
   /* methods[i + k + 1] := flags[k]; */
-  C_SUM_FIA( t_4, l_i, l_k );
-  C_SUM_FIA( t_3, t_4, INTOBJ_INT(1) );
-  CHECK_INT_POS( t_3 );
-  C_ELM_LIST_FPL( t_4, a_flags, l_k );
-  C_ASS_LIST_FPL( l_methods, t_3, t_4 );
+  C_SUM_FIA( t_4, l_i, l_k )
+  C_SUM_FIA( t_3, t_4, INTOBJ_INT(1) )
+  CHECK_INT_POS( t_3 )
+  C_ELM_LIST_FPL( t_4, a_flags, l_k )
+  C_ASS_LIST_FPL( l_methods, t_3, t_4 )
   
  }
  /* od */
@@ -1004,12 +1004,12 @@ static Obj  HdlrFunc3 (
  if ( t_1 ) {
   
   /* methods[i + (narg + 2)] := RETURN_TRUE; */
-  C_SUM_INTOBJS( t_2, l_narg, INTOBJ_INT(2) );
-  C_SUM_FIA( t_1, l_i, t_2 );
-  CHECK_INT_POS( t_1 );
+  C_SUM_INTOBJS( t_2, l_narg, INTOBJ_INT(2) )
+  C_SUM_FIA( t_1, l_i, t_2 )
+  CHECK_INT_POS( t_1 )
   t_2 = GC_RETURN__TRUE;
-  CHECK_BOUND( t_2, "RETURN_TRUE" );
-  C_ASS_LIST_FPL( l_methods, t_1, t_2 );
+  CHECK_BOUND( t_2, "RETURN_TRUE" )
+  C_ASS_LIST_FPL( l_methods, t_1, t_2 )
   
  }
  
@@ -1020,12 +1020,12 @@ static Obj  HdlrFunc3 (
   if ( t_1 ) {
    
    /* methods[i + (narg + 2)] := RETURN_FALSE; */
-   C_SUM_INTOBJS( t_2, l_narg, INTOBJ_INT(2) );
-   C_SUM_FIA( t_1, l_i, t_2 );
-   CHECK_INT_POS( t_1 );
+   C_SUM_INTOBJS( t_2, l_narg, INTOBJ_INT(2) )
+   C_SUM_FIA( t_1, l_i, t_2 )
+   CHECK_INT_POS( t_1 )
    t_2 = GC_RETURN__FALSE;
-   CHECK_BOUND( t_2, "RETURN_FALSE" );
-   C_ASS_LIST_FPL( l_methods, t_1, t_2 );
+   CHECK_BOUND( t_2, "RETURN_FALSE" )
+   C_ASS_LIST_FPL( l_methods, t_1, t_2 )
    
   }
   
@@ -1033,22 +1033,22 @@ static Obj  HdlrFunc3 (
   else {
    t_3 = GF_IS__FUNCTION;
    t_2 = CALL_1ARGS( t_3, a_method );
-   CHECK_FUNC_RESULT( t_2 );
-   CHECK_BOOL( t_2 );
+   CHECK_FUNC_RESULT( t_2 )
+   CHECK_BOOL( t_2 )
    t_1 = (Obj)(UInt)(t_2 != False);
    if ( t_1 ) {
     
     /* if CHECK_INSTALL_METHOD and not IS_OPERATION( method ) then */
     t_3 = GC_CHECK__INSTALL__METHOD;
-    CHECK_BOUND( t_3, "CHECK_INSTALL_METHOD" );
-    CHECK_BOOL( t_3 );
+    CHECK_BOUND( t_3, "CHECK_INSTALL_METHOD" )
+    CHECK_BOOL( t_3 )
     t_2 = (Obj)(UInt)(t_3 != False);
     t_1 = t_2;
     if ( t_1 ) {
      t_6 = GF_IS__OPERATION;
      t_5 = CALL_1ARGS( t_6, a_method );
-     CHECK_FUNC_RESULT( t_5 );
-     CHECK_BOOL( t_5 );
+     CHECK_FUNC_RESULT( t_5 )
+     CHECK_BOOL( t_5 )
      t_4 = (Obj)(UInt)(t_5 != False);
      t_3 = (Obj)(UInt)( ! ((Int)t_4) );
      t_1 = t_3;
@@ -1058,14 +1058,14 @@ static Obj  HdlrFunc3 (
      /* tmp := NARG_FUNC( method ); */
      t_2 = GF_NARG__FUNC;
      t_1 = CALL_1ARGS( t_2, a_method );
-     CHECK_FUNC_RESULT( t_1 );
+     CHECK_FUNC_RESULT( t_1 )
      l_tmp = t_1;
      
      /* if tmp < AINV( narg ) - 1 or tmp >= 0 and tmp <> narg then */
      t_5 = GF_AINV;
      t_4 = CALL_1ARGS( t_5, l_narg );
-     CHECK_FUNC_RESULT( t_4 );
-     C_DIFF_FIA( t_3, t_4, INTOBJ_INT(1) );
+     CHECK_FUNC_RESULT( t_4 )
+     C_DIFF_FIA( t_3, t_4, INTOBJ_INT(1) )
      t_2 = (Obj)(UInt)(LT( l_tmp, t_3 ));
      t_1 = t_2;
      if ( ! t_1 ) {
@@ -1083,7 +1083,7 @@ static Obj  HdlrFunc3 (
       t_1 = GF_Error;
       t_3 = GF_NAME__FUNC;
       t_2 = CALL_1ARGS( t_3, a_opr );
-      CHECK_FUNC_RESULT( t_2 );
+      CHECK_FUNC_RESULT( t_2 )
       C_NEW_STRING( t_3, 23, ": <method> must accept " );
       C_NEW_STRING( t_4, 10, " arguments" );
       CALL_4ARGS( t_1, t_2, t_3, l_narg, t_4 );
@@ -1095,10 +1095,10 @@ static Obj  HdlrFunc3 (
     /* fi */
     
     /* methods[i + (narg + 2)] := method; */
-    C_SUM_INTOBJS( t_2, l_narg, INTOBJ_INT(2) );
-    C_SUM_FIA( t_1, l_i, t_2 );
-    CHECK_INT_POS( t_1 );
-    C_ASS_LIST_FPL( l_methods, t_1, a_method );
+    C_SUM_INTOBJS( t_2, l_narg, INTOBJ_INT(2) )
+    C_SUM_FIA( t_1, l_i, t_2 )
+    CHECK_INT_POS( t_1 )
+    C_ASS_LIST_FPL( l_methods, t_1, a_method )
     
    }
    
@@ -1109,7 +1109,7 @@ static Obj  HdlrFunc3 (
     t_1 = GF_Error;
     t_3 = GF_NAME__FUNC;
     t_2 = CALL_1ARGS( t_3, a_opr );
-    CHECK_FUNC_RESULT( t_2 );
+    CHECK_FUNC_RESULT( t_2 )
     C_NEW_STRING( t_3, 49, ": <method> must be a function, `true', or `false'" );
     CALL_2ARGS( t_1, t_2, t_3 );
     
@@ -1119,19 +1119,19 @@ static Obj  HdlrFunc3 (
  /* fi */
  
  /* methods[i + (narg + 3)] := rank; */
- C_SUM_INTOBJS( t_2, l_narg, INTOBJ_INT(3) );
- C_SUM_FIA( t_1, l_i, t_2 );
- CHECK_INT_POS( t_1 );
- C_ASS_LIST_FPL( l_methods, t_1, a_rank );
+ C_SUM_INTOBJS( t_2, l_narg, INTOBJ_INT(3) )
+ C_SUM_FIA( t_1, l_i, t_2 )
+ CHECK_INT_POS( t_1 )
+ C_ASS_LIST_FPL( l_methods, t_1, a_rank )
  
  /* methods[i + (narg + 4)] := IMMUTABLE_COPY_OBJ( info ); */
- C_SUM_INTOBJS( t_2, l_narg, INTOBJ_INT(4) );
- C_SUM_FIA( t_1, l_i, t_2 );
- CHECK_INT_POS( t_1 );
+ C_SUM_INTOBJS( t_2, l_narg, INTOBJ_INT(4) )
+ C_SUM_FIA( t_1, l_i, t_2 )
+ CHECK_INT_POS( t_1 )
  t_3 = GF_IMMUTABLE__COPY__OBJ;
  t_2 = CALL_1ARGS( t_3, a_info );
- CHECK_FUNC_RESULT( t_2 );
- C_ASS_LIST_FPL( l_methods, t_1, t_2 );
+ CHECK_FUNC_RESULT( t_2 )
+ C_ASS_LIST_FPL( l_methods, t_1, t_2 )
  
  /* CHANGED_METHODS_OPERATION( opr, narg ); */
  t_1 = GF_CHANGED__METHODS__OPERATION;
@@ -1258,7 +1258,7 @@ static Obj  HdlrFunc6 (
  /* len := LEN_LIST( arglist ); */
  t_2 = GF_LEN__LIST;
  t_1 = CALL_1ARGS( t_2, a_arglist );
- CHECK_FUNC_RESULT( t_1 );
+ CHECK_FUNC_RESULT( t_1 )
  l_len = t_1;
  
  /* if len < 3 then */
@@ -1274,14 +1274,14 @@ static Obj  HdlrFunc6 (
  /* fi */
  
  /* opr := arglist[1]; */
- C_ELM_LIST_FPL( t_1, a_arglist, INTOBJ_INT(1) );
+ C_ELM_LIST_FPL( t_1, a_arglist, INTOBJ_INT(1) )
  l_opr = t_1;
  
  /* if not IS_OPERATION( opr ) then */
  t_4 = GF_IS__OPERATION;
  t_3 = CALL_1ARGS( t_4, l_opr );
- CHECK_FUNC_RESULT( t_3 );
- CHECK_BOOL( t_3 );
+ CHECK_FUNC_RESULT( t_3 )
+ CHECK_BOOL( t_3 )
  t_2 = (Obj)(UInt)(t_3 != False);
  t_1 = (Obj)(UInt)( ! ((Int)t_2) );
  if ( t_1 ) {
@@ -1296,15 +1296,15 @@ static Obj  HdlrFunc6 (
  
  /* if IS_STRING_REP( arglist[2] ) then */
  t_3 = GF_IS__STRING__REP;
- C_ELM_LIST_FPL( t_4, a_arglist, INTOBJ_INT(2) );
+ C_ELM_LIST_FPL( t_4, a_arglist, INTOBJ_INT(2) )
  t_2 = CALL_1ARGS( t_3, t_4 );
- CHECK_FUNC_RESULT( t_2 );
- CHECK_BOOL( t_2 );
+ CHECK_FUNC_RESULT( t_2 )
+ CHECK_BOOL( t_2 )
  t_1 = (Obj)(UInt)(t_2 != False);
  if ( t_1 ) {
   
   /* info := arglist[2]; */
-  C_ELM_LIST_FPL( t_1, a_arglist, INTOBJ_INT(2) );
+  C_ELM_LIST_FPL( t_1, a_arglist, INTOBJ_INT(2) )
   l_info = t_1;
   
   /* pos := 3; */
@@ -1326,27 +1326,27 @@ static Obj  HdlrFunc6 (
  /* fi */
  
  /* if arglist[pos] = true or IS_FUNCTION( arglist[pos] ) then */
- C_ELM_LIST_FPL( t_3, a_arglist, l_pos );
+ C_ELM_LIST_FPL( t_3, a_arglist, l_pos )
  t_4 = True;
  t_2 = (Obj)(UInt)(EQ( t_3, t_4 ));
  t_1 = t_2;
  if ( ! t_1 ) {
   t_5 = GF_IS__FUNCTION;
-  C_ELM_LIST_FPL( t_6, a_arglist, l_pos );
+  C_ELM_LIST_FPL( t_6, a_arglist, l_pos )
   t_4 = CALL_1ARGS( t_5, t_6 );
-  CHECK_FUNC_RESULT( t_4 );
-  CHECK_BOOL( t_4 );
+  CHECK_FUNC_RESULT( t_4 )
+  CHECK_BOOL( t_4 )
   t_3 = (Obj)(UInt)(t_4 != False);
   t_1 = t_3;
  }
  if ( t_1 ) {
   
   /* rel := arglist[pos]; */
-  C_ELM_LIST_FPL( t_1, a_arglist, l_pos );
+  C_ELM_LIST_FPL( t_1, a_arglist, l_pos )
   l_rel = t_1;
   
   /* pos := pos + 1; */
-  C_SUM_INTOBJS( t_1, l_pos, INTOBJ_INT(1) );
+  C_SUM_INTOBJS( t_1, l_pos, INTOBJ_INT(1) )
   l_pos = t_1;
   
  }
@@ -1362,17 +1362,17 @@ static Obj  HdlrFunc6 (
  /* fi */
  
  /* if not IsBound( arglist[pos] ) or not IS_LIST( arglist[pos] ) then */
- CHECK_INT_POS( l_pos );
+ CHECK_INT_POS( l_pos )
  t_4 = C_ISB_LIST( a_arglist, l_pos );
  t_3 = (Obj)(UInt)(t_4 != False);
  t_2 = (Obj)(UInt)( ! ((Int)t_3) );
  t_1 = t_2;
  if ( ! t_1 ) {
   t_6 = GF_IS__LIST;
-  C_ELM_LIST_FPL( t_7, a_arglist, l_pos );
+  C_ELM_LIST_FPL( t_7, a_arglist, l_pos )
   t_5 = CALL_1ARGS( t_6, t_7 );
-  CHECK_FUNC_RESULT( t_5 );
-  CHECK_BOOL( t_5 );
+  CHECK_FUNC_RESULT( t_5 )
+  CHECK_BOOL( t_5 )
   t_4 = (Obj)(UInt)(t_5 != False);
   t_3 = (Obj)(UInt)( ! ((Int)t_4) );
   t_1 = t_3;
@@ -1389,16 +1389,16 @@ static Obj  HdlrFunc6 (
  /* fi */
  
  /* filters := arglist[pos]; */
- C_ELM_LIST_FPL( t_1, a_arglist, l_pos );
+ C_ELM_LIST_FPL( t_1, a_arglist, l_pos )
  l_filters = t_1;
  
  /* if GAPInfo.MaxNrArgsMethod < LEN_LIST( filters ) then */
  t_3 = GC_GAPInfo;
- CHECK_BOUND( t_3, "GAPInfo" );
+ CHECK_BOUND( t_3, "GAPInfo" )
  t_2 = ELM_REC( t_3, R_MaxNrArgsMethod );
  t_4 = GF_LEN__LIST;
  t_3 = CALL_1ARGS( t_4, l_filters );
- CHECK_FUNC_RESULT( t_3 );
+ CHECK_FUNC_RESULT( t_3 )
  t_1 = (Obj)(UInt)(LT( t_2, t_3 ));
  if ( t_1 ) {
   
@@ -1406,7 +1406,7 @@ static Obj  HdlrFunc6 (
   t_1 = GF_Error;
   C_NEW_STRING( t_2, 25, "methods can have at most " );
   t_4 = GC_GAPInfo;
-  CHECK_BOUND( t_4, "GAPInfo" );
+  CHECK_BOUND( t_4, "GAPInfo" )
   t_3 = ELM_REC( t_4, R_MaxNrArgsMethod );
   C_NEW_STRING( t_4, 10, " arguments" );
   CALL_3ARGS( t_1, t_2, t_3, t_4 );
@@ -1417,7 +1417,7 @@ static Obj  HdlrFunc6 (
  /* if 0 < LEN_LIST( filters ) then */
  t_3 = GF_LEN__LIST;
  t_2 = CALL_1ARGS( t_3, l_filters );
- CHECK_FUNC_RESULT( t_2 );
+ CHECK_FUNC_RESULT( t_2 )
  t_1 = (Obj)(UInt)(LT( INTOBJ_INT(0), t_2 ));
  if ( t_1 ) {
   
@@ -1432,8 +1432,8 @@ static Obj  HdlrFunc6 (
   /* for i in [ 1 .. LEN_LIST( filters ) ] do */
   t_3 = GF_LEN__LIST;
   t_2 = CALL_1ARGS( t_3, l_filters );
-  CHECK_FUNC_RESULT( t_2 );
-  CHECK_INT_SMALL( t_2 );
+  CHECK_FUNC_RESULT( t_2 )
+  CHECK_INT_SMALL( t_2 )
   for ( t_1 = INTOBJ_INT(1);
         ((Int)t_1) <= ((Int)t_2);
         t_1 = (Obj)(((UInt)t_1)+4) ) {
@@ -1441,16 +1441,16 @@ static Obj  HdlrFunc6 (
    
    /* if IS_STRING_REP( filters[i] ) then */
    t_5 = GF_IS__STRING__REP;
-   C_ELM_LIST_FPL( t_6, l_filters, l_i );
+   C_ELM_LIST_FPL( t_6, l_filters, l_i )
    t_4 = CALL_1ARGS( t_5, t_6 );
-   CHECK_FUNC_RESULT( t_4 );
-   CHECK_BOOL( t_4 );
+   CHECK_FUNC_RESULT( t_4 )
+   CHECK_BOOL( t_4 )
    t_3 = (Obj)(UInt)(t_4 != False);
    if ( t_3 ) {
     
     /* APPEND_LIST_INTR( info1, filters[i] ); */
     t_3 = GF_APPEND__LIST__INTR;
-    C_ELM_LIST_FPL( t_4, l_filters, l_i );
+    C_ELM_LIST_FPL( t_4, l_filters, l_i )
     CALL_2ARGS( t_3, l_info1, t_4 );
     
     /* APPEND_LIST_INTR( info1, ", " ); */
@@ -1460,17 +1460,17 @@ static Obj  HdlrFunc6 (
     
     /* filters[i] := EvalString( filters[i] ); */
     t_4 = GF_EvalString;
-    C_ELM_LIST_FPL( t_5, l_filters, l_i );
+    C_ELM_LIST_FPL( t_5, l_filters, l_i )
     t_3 = CALL_1ARGS( t_4, t_5 );
-    CHECK_FUNC_RESULT( t_3 );
-    C_ASS_LIST_FPL( l_filters, l_i, t_3 );
+    CHECK_FUNC_RESULT( t_3 )
+    C_ASS_LIST_FPL( l_filters, l_i, t_3 )
     
     /* if not IS_FUNCTION( filters[i] ) then */
     t_6 = GF_IS__FUNCTION;
-    C_ELM_LIST_FPL( t_7, l_filters, l_i );
+    C_ELM_LIST_FPL( t_7, l_filters, l_i )
     t_5 = CALL_1ARGS( t_6, t_7 );
-    CHECK_FUNC_RESULT( t_5 );
-    CHECK_BOOL( t_5 );
+    CHECK_FUNC_RESULT( t_5 )
+    CHECK_BOOL( t_5 )
     t_4 = (Obj)(UInt)(t_5 != False);
     t_3 = (Obj)(UInt)( ! ((Int)t_4) );
     if ( t_3 ) {
@@ -1514,19 +1514,19 @@ static Obj  HdlrFunc6 (
    /* info1[LEN_LIST( info1 ) - 1] := ' '; */
    t_3 = GF_LEN__LIST;
    t_2 = CALL_1ARGS( t_3, l_info1 );
-   CHECK_FUNC_RESULT( t_2 );
-   C_DIFF_FIA( t_1, t_2, INTOBJ_INT(1) );
-   CHECK_INT_POS( t_1 );
+   CHECK_FUNC_RESULT( t_2 )
+   C_DIFF_FIA( t_1, t_2, INTOBJ_INT(1) )
+   CHECK_INT_POS( t_1 )
    t_2 = ObjsChar[32];
-   C_ASS_LIST_FPL( l_info1, t_1, t_2 );
+   C_ASS_LIST_FPL( l_info1, t_1, t_2 )
    
    /* info1[LEN_LIST( info1 )] := ']'; */
    t_2 = GF_LEN__LIST;
    t_1 = CALL_1ARGS( t_2, l_info1 );
-   CHECK_FUNC_RESULT( t_1 );
-   CHECK_INT_POS( t_1 );
+   CHECK_FUNC_RESULT( t_1 )
+   CHECK_INT_POS( t_1 )
    t_2 = ObjsChar[93];
-   C_ASS_LIST_FPL( l_info1, t_1, t_2 );
+   C_ASS_LIST_FPL( l_info1, t_1, t_2 )
    
    /* info := info1; */
    l_info = l_info1;
@@ -1538,7 +1538,7 @@ static Obj  HdlrFunc6 (
  /* fi */
  
  /* pos := pos + 1; */
- C_SUM_FIA( t_1, l_pos, INTOBJ_INT(1) );
+ C_SUM_FIA( t_1, l_pos, INTOBJ_INT(1) )
  l_pos = t_1;
  
  /* flags := [  ]; */
@@ -1573,14 +1573,14 @@ static Obj  HdlrFunc6 (
   t_5 = GF_ADD__LIST;
   t_7 = GF_FLAGS__FILTER;
   t_6 = CALL_1ARGS( t_7, l_i );
-  CHECK_FUNC_RESULT( t_6 );
+  CHECK_FUNC_RESULT( t_6 )
   CALL_2ARGS( t_5, l_flags, t_6 );
   
  }
  /* od */
  
  /* if not IsBound( arglist[pos] ) then */
- CHECK_INT_POS( l_pos );
+ CHECK_INT_POS( l_pos )
  t_3 = C_ISB_LIST( a_arglist, l_pos );
  t_2 = (Obj)(UInt)(t_3 != False);
  t_1 = (Obj)(UInt)( ! ((Int)t_2) );
@@ -1596,19 +1596,19 @@ static Obj  HdlrFunc6 (
  /* elif IS_INT( arglist[pos] ) then */
  else {
   t_3 = GF_IS__INT;
-  C_ELM_LIST_FPL( t_4, a_arglist, l_pos );
+  C_ELM_LIST_FPL( t_4, a_arglist, l_pos )
   t_2 = CALL_1ARGS( t_3, t_4 );
-  CHECK_FUNC_RESULT( t_2 );
-  CHECK_BOOL( t_2 );
+  CHECK_FUNC_RESULT( t_2 )
+  CHECK_BOOL( t_2 )
   t_1 = (Obj)(UInt)(t_2 != False);
   if ( t_1 ) {
    
    /* rank := arglist[pos]; */
-   C_ELM_LIST_FPL( t_1, a_arglist, l_pos );
+   C_ELM_LIST_FPL( t_1, a_arglist, l_pos )
    l_rank = t_1;
    
    /* pos := pos + 1; */
-   C_SUM_FIA( t_1, l_pos, INTOBJ_INT(1) );
+   C_SUM_FIA( t_1, l_pos, INTOBJ_INT(1) )
    l_pos = t_1;
    
   }
@@ -1624,7 +1624,7 @@ static Obj  HdlrFunc6 (
  /* fi */
  
  /* if not IsBound( arglist[pos] ) then */
- CHECK_INT_POS( l_pos );
+ CHECK_INT_POS( l_pos )
  t_3 = C_ISB_LIST( a_arglist, l_pos );
  t_2 = (Obj)(UInt)(t_3 != False);
  t_1 = (Obj)(UInt)( ! ((Int)t_2) );
@@ -1639,13 +1639,13 @@ static Obj  HdlrFunc6 (
  /* fi */
  
  /* method := arglist[pos]; */
- C_ELM_LIST_FPL( t_1, a_arglist, l_pos );
+ C_ELM_LIST_FPL( t_1, a_arglist, l_pos )
  l_method = t_1;
  
  /* if FLAG1_FILTER( opr ) <> 0 and (rel = true or rel = RETURN_TRUE) and LEN_LIST( filters ) = 1 and (method = true or method = RETURN_TRUE) then */
  t_6 = GF_FLAG1__FILTER;
  t_5 = CALL_1ARGS( t_6, l_opr );
- CHECK_FUNC_RESULT( t_5 );
+ CHECK_FUNC_RESULT( t_5 )
  t_4 = (Obj)(UInt)( ! EQ( t_5, INTOBJ_INT(0) ));
  t_3 = t_4;
  if ( t_3 ) {
@@ -1654,7 +1654,7 @@ static Obj  HdlrFunc6 (
   t_5 = t_6;
   if ( ! t_5 ) {
    t_8 = GC_RETURN__TRUE;
-   CHECK_BOUND( t_8, "RETURN_TRUE" );
+   CHECK_BOUND( t_8, "RETURN_TRUE" )
    t_7 = (Obj)(UInt)(EQ( l_rel, t_8 ));
    t_5 = t_7;
   }
@@ -1664,7 +1664,7 @@ static Obj  HdlrFunc6 (
  if ( t_2 ) {
   t_6 = GF_LEN__LIST;
   t_5 = CALL_1ARGS( t_6, l_filters );
-  CHECK_FUNC_RESULT( t_5 );
+  CHECK_FUNC_RESULT( t_5 )
   t_4 = (Obj)(UInt)(EQ( t_5, INTOBJ_INT(1) ));
   t_2 = t_4;
  }
@@ -1675,7 +1675,7 @@ static Obj  HdlrFunc6 (
   t_3 = t_4;
   if ( ! t_3 ) {
    t_6 = GC_RETURN__TRUE;
-   CHECK_BOUND( t_6, "RETURN_TRUE" );
+   CHECK_BOUND( t_6, "RETURN_TRUE" )
    t_5 = (Obj)(UInt)(EQ( l_method, t_6 ));
    t_3 = t_5;
   }
@@ -1687,7 +1687,7 @@ static Obj  HdlrFunc6 (
   t_1 = GF_Error;
   t_3 = GF_NAME__FUNC;
   t_2 = CALL_1ARGS( t_3, l_opr );
-  CHECK_FUNC_RESULT( t_2 );
+  CHECK_FUNC_RESULT( t_2 )
   C_NEW_STRING( t_3, 35, ": use `InstallTrueMethod' for <opr>" );
   CALL_2ARGS( t_1, t_2, t_3 );
   
@@ -1696,12 +1696,12 @@ static Obj  HdlrFunc6 (
  
  /* if CHECK_INSTALL_METHOD and check then */
  t_3 = GC_CHECK__INSTALL__METHOD;
- CHECK_BOUND( t_3, "CHECK_INSTALL_METHOD" );
- CHECK_BOOL( t_3 );
+ CHECK_BOUND( t_3, "CHECK_INSTALL_METHOD" )
+ CHECK_BOOL( t_3 )
  t_2 = (Obj)(UInt)(t_3 != False);
  t_1 = t_2;
  if ( t_1 ) {
-  CHECK_BOOL( a_check );
+  CHECK_BOOL( a_check )
   t_3 = (Obj)(UInt)(a_check != False);
   t_1 = t_3;
  }
@@ -1709,7 +1709,7 @@ static Obj  HdlrFunc6 (
   
   /* if opr in WRAPPER_OPERATIONS then */
   t_2 = GC_WRAPPER__OPERATIONS;
-  CHECK_BOUND( t_2, "WRAPPER_OPERATIONS" );
+  CHECK_BOUND( t_2, "WRAPPER_OPERATIONS" )
   t_1 = (Obj)(UInt)(IN( l_opr, t_2 ));
   if ( t_1 ) {
    
@@ -1718,7 +1718,7 @@ static Obj  HdlrFunc6 (
    C_NEW_STRING( t_2, 48, "a method is installed for the wrapper operation " );
    t_4 = GF_NAME__FUNC;
    t_3 = CALL_1ARGS( t_4, l_opr );
-   CHECK_FUNC_RESULT( t_3 );
+   CHECK_FUNC_RESULT( t_3 )
    C_NEW_STRING( t_4, 1, "\n" );
    C_NEW_STRING( t_5, 53, "#I  probably it should be installed for (one of) its\n" );
    C_NEW_STRING( t_6, 27, "#I  underlying operation(s)" );
@@ -1734,10 +1734,10 @@ static Obj  HdlrFunc6 (
   /* for i in [ 1, 3 .. LEN_LIST( OPERATIONS ) - 1 ] do */
   t_7 = GF_LEN__LIST;
   t_8 = GC_OPERATIONS;
-  CHECK_BOUND( t_8, "OPERATIONS" );
+  CHECK_BOUND( t_8, "OPERATIONS" )
   t_6 = CALL_1ARGS( t_7, t_8 );
-  CHECK_FUNC_RESULT( t_6 );
-  C_DIFF_FIA( t_5, t_6, INTOBJ_INT(1) );
+  CHECK_FUNC_RESULT( t_6 )
+  C_DIFF_FIA( t_5, t_6, INTOBJ_INT(1) )
   t_4 = Range3Check( INTOBJ_INT(1), INTOBJ_INT(3), t_5 );
   if ( IS_SMALL_LIST(t_4) ) {
    t_3 = (Obj)(UInt)1;
@@ -1763,21 +1763,21 @@ static Obj  HdlrFunc6 (
    /* if IS_IDENTICAL_OBJ( OPERATIONS[i], opr ) then */
    t_7 = GF_IS__IDENTICAL__OBJ;
    t_9 = GC_OPERATIONS;
-   CHECK_BOUND( t_9, "OPERATIONS" );
-   CHECK_INT_POS( l_i );
-   C_ELM_LIST_FPL( t_8, t_9, l_i );
+   CHECK_BOUND( t_9, "OPERATIONS" )
+   CHECK_INT_POS( l_i )
+   C_ELM_LIST_FPL( t_8, t_9, l_i )
    t_6 = CALL_2ARGS( t_7, t_8, l_opr );
-   CHECK_FUNC_RESULT( t_6 );
-   CHECK_BOOL( t_6 );
+   CHECK_FUNC_RESULT( t_6 )
+   CHECK_BOOL( t_6 )
    t_5 = (Obj)(UInt)(t_6 != False);
    if ( t_5 ) {
     
     /* req := OPERATIONS[i + 1]; */
     t_6 = GC_OPERATIONS;
-    CHECK_BOUND( t_6, "OPERATIONS" );
-    C_SUM_FIA( t_7, l_i, INTOBJ_INT(1) );
-    CHECK_INT_POS( t_7 );
-    C_ELM_LIST_FPL( t_5, t_6, t_7 );
+    CHECK_BOUND( t_6, "OPERATIONS" )
+    C_SUM_FIA( t_7, l_i, INTOBJ_INT(1) )
+    CHECK_INT_POS( t_7 )
+    C_ELM_LIST_FPL( t_5, t_6, t_7 )
     l_req = t_5;
     
     /* break; */
@@ -1799,7 +1799,7 @@ static Obj  HdlrFunc6 (
    C_NEW_STRING( t_2, 18, "unknown operation " );
    t_4 = GF_NAME__FUNC;
    t_3 = CALL_1ARGS( t_4, l_opr );
-   CHECK_FUNC_RESULT( t_3 );
+   CHECK_FUNC_RESULT( t_3 )
    CALL_2ARGS( t_1, t_2, t_3 );
    
   }
@@ -1837,7 +1837,7 @@ static Obj  HdlrFunc6 (
    t_5 = GF_ADD__LIST;
    t_7 = GF_WITH__HIDDEN__IMPS__FLAGS;
    t_6 = CALL_1ARGS( t_7, l_i );
-   CHECK_FUNC_RESULT( t_6 );
+   CHECK_FUNC_RESULT( t_6 )
    CALL_2ARGS( t_5, l_imp, t_6 );
    
   }
@@ -1857,7 +1857,7 @@ static Obj  HdlrFunc6 (
   while ( 1 ) {
    t_4 = GF_LEN__LIST;
    t_3 = CALL_1ARGS( t_4, l_req );
-   CHECK_FUNC_RESULT( t_3 );
+   CHECK_FUNC_RESULT( t_3 )
    t_2 = (Obj)(UInt)(LT( l_j, t_3 ));
    t_1 = t_2;
    if ( t_1 ) {
@@ -1868,21 +1868,21 @@ static Obj  HdlrFunc6 (
    if ( ! t_1 ) break;
    
    /* j := j + 1; */
-   C_SUM_FIA( t_1, l_j, INTOBJ_INT(1) );
+   C_SUM_FIA( t_1, l_j, INTOBJ_INT(1) )
    l_j = t_1;
    
    /* reqs := req[j]; */
-   CHECK_INT_POS( l_j );
-   C_ELM_LIST_FPL( t_1, l_req, l_j );
+   CHECK_INT_POS( l_j )
+   C_ELM_LIST_FPL( t_1, l_req, l_j )
    l_reqs = t_1;
    
    /* if LEN_LIST( reqs ) = LEN_LIST( imp ) then */
    t_3 = GF_LEN__LIST;
    t_2 = CALL_1ARGS( t_3, l_reqs );
-   CHECK_FUNC_RESULT( t_2 );
+   CHECK_FUNC_RESULT( t_2 )
    t_4 = GF_LEN__LIST;
    t_3 = CALL_1ARGS( t_4, l_imp );
-   CHECK_FUNC_RESULT( t_3 );
+   CHECK_FUNC_RESULT( t_3 )
    t_1 = (Obj)(UInt)(EQ( t_2, t_3 ));
    if ( t_1 ) {
     
@@ -1893,8 +1893,8 @@ static Obj  HdlrFunc6 (
     /* for i in [ 1 .. LEN_LIST( reqs ) ] do */
     t_3 = GF_LEN__LIST;
     t_2 = CALL_1ARGS( t_3, l_reqs );
-    CHECK_FUNC_RESULT( t_2 );
-    CHECK_INT_SMALL( t_2 );
+    CHECK_FUNC_RESULT( t_2 )
+    CHECK_INT_SMALL( t_2 )
     for ( t_1 = INTOBJ_INT(1);
           ((Int)t_1) <= ((Int)t_2);
           t_1 = (Obj)(((UInt)t_1)+4) ) {
@@ -1902,11 +1902,11 @@ static Obj  HdlrFunc6 (
      
      /* if not IS_SUBSET_FLAGS( imp[i], reqs[i] ) then */
      t_6 = GF_IS__SUBSET__FLAGS;
-     C_ELM_LIST_FPL( t_7, l_imp, l_i );
-     C_ELM_LIST_FPL( t_8, l_reqs, l_i );
+     C_ELM_LIST_FPL( t_7, l_imp, l_i )
+     C_ELM_LIST_FPL( t_8, l_reqs, l_i )
      t_5 = CALL_2ARGS( t_6, t_7, t_8 );
-     CHECK_FUNC_RESULT( t_5 );
-     CHECK_BOOL( t_5 );
+     CHECK_FUNC_RESULT( t_5 )
+     CHECK_BOOL( t_5 )
      t_4 = (Obj)(UInt)(t_5 != False);
      t_3 = (Obj)(UInt)( ! ((Int)t_4) );
      if ( t_3 ) {
@@ -1957,7 +1957,7 @@ static Obj  HdlrFunc6 (
     C_NEW_STRING( t_2, 56, "the number of arguments does not match a declaration of " );
     t_4 = GF_NAME__FUNC;
     t_3 = CALL_1ARGS( t_4, l_opr );
-    CHECK_FUNC_RESULT( t_3 );
+    CHECK_FUNC_RESULT( t_3 )
     CALL_2ARGS( t_1, t_2, t_3 );
     
    }
@@ -1969,18 +1969,18 @@ static Obj  HdlrFunc6 (
     t_1 = GF_Error;
     C_NEW_STRING( t_2, 17, "required filters " );
     t_4 = GF_NamesFilter;
-    CHECK_INT_POS( l_notmatch );
-    C_ELM_LIST_FPL( t_5, l_imp, l_notmatch );
+    CHECK_INT_POS( l_notmatch )
+    C_ELM_LIST_FPL( t_5, l_imp, l_notmatch )
     t_3 = CALL_1ARGS( t_4, t_5 );
-    CHECK_FUNC_RESULT( t_3 );
+    CHECK_FUNC_RESULT( t_3 )
     C_NEW_STRING( t_4, 5, "\nfor " );
     t_6 = GF_Ordinal;
     t_5 = CALL_1ARGS( t_6, l_notmatch );
-    CHECK_FUNC_RESULT( t_5 );
+    CHECK_FUNC_RESULT( t_5 )
     C_NEW_STRING( t_6, 40, " argument do not match a declaration of " );
     t_8 = GF_NAME__FUNC;
     t_7 = CALL_1ARGS( t_8, l_opr );
-    CHECK_FUNC_RESULT( t_7 );
+    CHECK_FUNC_RESULT( t_7 )
     CALL_6ARGS( t_1, t_2, t_3, t_4, t_5, t_6, t_7 );
     
    }
@@ -1995,29 +1995,29 @@ static Obj  HdlrFunc6 (
    l_oreqs = l_reqs;
    
    /* for k in [ j + 1 .. LEN_LIST( req ) ] do */
-   C_SUM_FIA( t_2, l_j, INTOBJ_INT(1) );
-   CHECK_INT_SMALL( t_2 );
+   C_SUM_FIA( t_2, l_j, INTOBJ_INT(1) )
+   CHECK_INT_SMALL( t_2 )
    t_4 = GF_LEN__LIST;
    t_3 = CALL_1ARGS( t_4, l_req );
-   CHECK_FUNC_RESULT( t_3 );
-   CHECK_INT_SMALL( t_3 );
+   CHECK_FUNC_RESULT( t_3 )
+   CHECK_INT_SMALL( t_3 )
    for ( t_1 = t_2;
          ((Int)t_1) <= ((Int)t_3);
          t_1 = (Obj)(((UInt)t_1)+4) ) {
     l_k = t_1;
     
     /* reqs := req[k]; */
-    CHECK_INT_POS( l_k );
-    C_ELM_LIST_FPL( t_4, l_req, l_k );
+    CHECK_INT_POS( l_k )
+    C_ELM_LIST_FPL( t_4, l_req, l_k )
     l_reqs = t_4;
     
     /* if LEN_LIST( reqs ) = LEN_LIST( imp ) then */
     t_6 = GF_LEN__LIST;
     t_5 = CALL_1ARGS( t_6, l_reqs );
-    CHECK_FUNC_RESULT( t_5 );
+    CHECK_FUNC_RESULT( t_5 )
     t_7 = GF_LEN__LIST;
     t_6 = CALL_1ARGS( t_7, l_imp );
-    CHECK_FUNC_RESULT( t_6 );
+    CHECK_FUNC_RESULT( t_6 )
     t_4 = (Obj)(UInt)(EQ( t_5, t_6 ));
     if ( t_4 ) {
      
@@ -2028,8 +2028,8 @@ static Obj  HdlrFunc6 (
      /* for i in [ 1 .. LEN_LIST( reqs ) ] do */
      t_6 = GF_LEN__LIST;
      t_5 = CALL_1ARGS( t_6, l_reqs );
-     CHECK_FUNC_RESULT( t_5 );
-     CHECK_INT_SMALL( t_5 );
+     CHECK_FUNC_RESULT( t_5 )
+     CHECK_INT_SMALL( t_5 )
      for ( t_4 = INTOBJ_INT(1);
            ((Int)t_4) <= ((Int)t_5);
            t_4 = (Obj)(((UInt)t_4)+4) ) {
@@ -2037,11 +2037,11 @@ static Obj  HdlrFunc6 (
       
       /* if not IS_SUBSET_FLAGS( imp[i], reqs[i] ) then */
       t_9 = GF_IS__SUBSET__FLAGS;
-      C_ELM_LIST_FPL( t_10, l_imp, l_i );
-      C_ELM_LIST_FPL( t_11, l_reqs, l_i );
+      C_ELM_LIST_FPL( t_10, l_imp, l_i )
+      C_ELM_LIST_FPL( t_11, l_reqs, l_i )
       t_8 = CALL_2ARGS( t_9, t_10, t_11 );
-      CHECK_FUNC_RESULT( t_8 );
-      CHECK_BOOL( t_8 );
+      CHECK_FUNC_RESULT( t_8 )
+      CHECK_BOOL( t_8 )
       t_7 = (Obj)(UInt)(t_8 != False);
       t_6 = (Obj)(UInt)( ! ((Int)t_7) );
       if ( t_6 ) {
@@ -2073,7 +2073,7 @@ static Obj  HdlrFunc6 (
       C_NEW_STRING( t_5, 21, "method installed for " );
       t_7 = GF_NAME__FUNC;
       t_6 = CALL_1ARGS( t_7, l_opr );
-      CHECK_FUNC_RESULT( t_6 );
+      CHECK_FUNC_RESULT( t_6 )
       C_NEW_STRING( t_7, 34, " matches more than one declaration" );
       CALL_4ARGS( t_4, INTOBJ_INT(1), t_5, t_6, t_7 );
       
@@ -2094,7 +2094,7 @@ static Obj  HdlrFunc6 (
  
  /* INSTALL_METHOD_FLAGS( opr, info, rel, flags, rank, method ); */
  t_1 = GF_INSTALL__METHOD__FLAGS;
- CHECK_BOUND( l_rank, "rank" );
+ CHECK_BOUND( l_rank, "rank" )
  CALL_6ARGS( t_1, l_opr, l_info, l_rel, l_flags, l_rank, l_method );
  
  /* return; */
@@ -2140,7 +2140,7 @@ static Obj  HdlrFunc8 (
  
  /* for prop in props do */
  t_4 = OBJ_LVAR_1UP( 2 );
- CHECK_BOUND( t_4, "props" );
+ CHECK_BOUND( t_4, "props" )
  if ( IS_SMALL_LIST(t_4) ) {
   t_3 = (Obj)(UInt)1;
   t_1 = INTOBJ_INT(1);
@@ -2165,11 +2165,11 @@ static Obj  HdlrFunc8 (
   /* if not Tester( prop )( obj ) then */
   t_9 = GF_Tester;
   t_8 = CALL_1ARGS( t_9, l_prop );
-  CHECK_FUNC_RESULT( t_8 );
-  CHECK_FUNC( t_8 );
+  CHECK_FUNC_RESULT( t_8 )
+  CHECK_FUNC( t_8 )
   t_7 = CALL_1ARGS( t_8, a_obj );
-  CHECK_FUNC_RESULT( t_7 );
-  CHECK_BOOL( t_7 );
+  CHECK_FUNC_RESULT( t_7 )
+  CHECK_BOOL( t_7 )
   t_6 = (Obj)(UInt)(t_7 != False);
   t_5 = (Obj)(UInt)( ! ((Int)t_6) );
   if ( t_5 ) {
@@ -2179,20 +2179,20 @@ static Obj  HdlrFunc8 (
    l_found = t_5;
    
    /* if not (prop( obj ) and Tester( prop )( obj )) then */
-   CHECK_FUNC( l_prop );
+   CHECK_FUNC( l_prop )
    t_8 = CALL_1ARGS( l_prop, a_obj );
-   CHECK_FUNC_RESULT( t_8 );
-   CHECK_BOOL( t_8 );
+   CHECK_FUNC_RESULT( t_8 )
+   CHECK_BOOL( t_8 )
    t_7 = (Obj)(UInt)(t_8 != False);
    t_6 = t_7;
    if ( t_6 ) {
     t_11 = GF_Tester;
     t_10 = CALL_1ARGS( t_11, l_prop );
-    CHECK_FUNC_RESULT( t_10 );
-    CHECK_FUNC( t_10 );
+    CHECK_FUNC_RESULT( t_10 )
+    CHECK_FUNC( t_10 )
     t_9 = CALL_1ARGS( t_10, a_obj );
-    CHECK_FUNC_RESULT( t_9 );
-    CHECK_BOOL( t_9 );
+    CHECK_FUNC_RESULT( t_9 )
+    CHECK_BOOL( t_9 )
     t_8 = (Obj)(UInt)(t_9 != False);
     t_6 = t_8;
    }
@@ -2201,7 +2201,7 @@ static Obj  HdlrFunc8 (
     
     /* return TRY_NEXT_METHOD; */
     t_5 = GC_TRY__NEXT__METHOD;
-    CHECK_BOUND( t_5, "TRY_NEXT_METHOD" );
+    CHECK_BOUND( t_5, "TRY_NEXT_METHOD" )
     RES_BRK_CURR_STAT();
     SWITCH_TO_OLD_FRAME(oldFrame);
     return t_5;
@@ -2221,10 +2221,10 @@ static Obj  HdlrFunc8 (
   
   /* return getter( obj ); */
   t_2 = OBJ_LVAR_1UP( 1 );
-  CHECK_BOUND( t_2, "getter" );
-  CHECK_FUNC( t_2 );
+  CHECK_BOUND( t_2, "getter" )
+  CHECK_FUNC( t_2 )
   t_1 = CALL_1ARGS( t_2, a_obj );
-  CHECK_FUNC_RESULT( t_1 );
+  CHECK_FUNC_RESULT( t_1 )
   RES_BRK_CURR_STAT();
   SWITCH_TO_OLD_FRAME(oldFrame);
   return t_1;
@@ -2236,7 +2236,7 @@ static Obj  HdlrFunc8 (
   
   /* return TRY_NEXT_METHOD; */
   t_1 = GC_TRY__NEXT__METHOD;
-  CHECK_BOUND( t_1, "TRY_NEXT_METHOD" );
+  CHECK_BOUND( t_1, "TRY_NEXT_METHOD" )
   RES_BRK_CURR_STAT();
   SWITCH_TO_OLD_FRAME(oldFrame);
   return t_1;
@@ -2288,10 +2288,10 @@ static Obj  HdlrFunc7 (
  /* if not IS_IDENTICAL_OBJ( filter, IS_OBJECT ) then */
  t_4 = GF_IS__IDENTICAL__OBJ;
  t_5 = GC_IS__OBJECT;
- CHECK_BOUND( t_5, "IS_OBJECT" );
+ CHECK_BOUND( t_5, "IS_OBJECT" )
  t_3 = CALL_2ARGS( t_4, a_filter, t_5 );
- CHECK_FUNC_RESULT( t_3 );
- CHECK_BOOL( t_3 );
+ CHECK_FUNC_RESULT( t_3 )
+ CHECK_BOOL( t_3 )
  t_2 = (Obj)(UInt)(t_3 != False);
  t_1 = (Obj)(UInt)( ! ((Int)t_2) );
  if ( t_1 ) {
@@ -2299,7 +2299,7 @@ static Obj  HdlrFunc7 (
   /* flags := FLAGS_FILTER( filter ); */
   t_2 = GF_FLAGS__FILTER;
   t_1 = CALL_1ARGS( t_2, a_filter );
-  CHECK_FUNC_RESULT( t_1 );
+  CHECK_FUNC_RESULT( t_1 )
   l_flags = t_1;
   
   /* rank := 0; */
@@ -2307,7 +2307,7 @@ static Obj  HdlrFunc7 (
   
   /* cats := IS_OBJECT; */
   t_1 = GC_IS__OBJECT;
-  CHECK_BOUND( t_1, "IS_OBJECT" );
+  CHECK_BOUND( t_1, "IS_OBJECT" )
   l_cats = t_1;
   
   /* props := [  ]; */
@@ -2318,8 +2318,8 @@ static Obj  HdlrFunc7 (
   /* for i in [ 1 .. LEN_FLAGS( flags ) ] do */
   t_3 = GF_LEN__FLAGS;
   t_2 = CALL_1ARGS( t_3, l_flags );
-  CHECK_FUNC_RESULT( t_2 );
-  CHECK_INT_SMALL( t_2 );
+  CHECK_FUNC_RESULT( t_2 )
+  CHECK_INT_SMALL( t_2 )
   for ( t_1 = INTOBJ_INT(1);
         ((Int)t_1) <= ((Int)t_2);
         t_1 = (Obj)(((UInt)t_1)+4) ) {
@@ -2328,14 +2328,14 @@ static Obj  HdlrFunc7 (
    /* if ELM_FLAGS( flags, i ) then */
    t_5 = GF_ELM__FLAGS;
    t_4 = CALL_2ARGS( t_5, l_flags, l_i );
-   CHECK_FUNC_RESULT( t_4 );
-   CHECK_BOOL( t_4 );
+   CHECK_FUNC_RESULT( t_4 )
+   CHECK_BOOL( t_4 )
    t_3 = (Obj)(UInt)(t_4 != False);
    if ( t_3 ) {
     
     /* if i in CATS_AND_REPS then */
     t_4 = GC_CATS__AND__REPS;
-    CHECK_BOUND( t_4, "CATS_AND_REPS" );
+    CHECK_BOUND( t_4, "CATS_AND_REPS" )
     t_3 = (Obj)(UInt)(IN( l_i, t_4 ));
     if ( t_3 ) {
      
@@ -2345,17 +2345,17 @@ static Obj  HdlrFunc7 (
      }
      else if ( l_cats == True ) {
       t_5 = GC_FILTERS;
-      CHECK_BOUND( t_5, "FILTERS" );
-      C_ELM_LIST_FPL( t_4, t_5, l_i );
-      CHECK_BOOL( t_4 );
+      CHECK_BOUND( t_5, "FILTERS" )
+      C_ELM_LIST_FPL( t_4, t_5, l_i )
+      CHECK_BOOL( t_4 )
       t_3 = t_4;
      }
      else {
-      CHECK_FUNC( l_cats );
+      CHECK_FUNC( l_cats )
       t_6 = GC_FILTERS;
-      CHECK_BOUND( t_6, "FILTERS" );
-      C_ELM_LIST_FPL( t_5, t_6, l_i );
-      CHECK_FUNC( t_5 );
+      CHECK_BOUND( t_6, "FILTERS" )
+      C_ELM_LIST_FPL( t_5, t_6, l_i )
+      CHECK_FUNC( t_5 )
       t_3 = NewAndFilter( l_cats, t_5 );
      }
      l_cats = t_3;
@@ -2363,11 +2363,11 @@ static Obj  HdlrFunc7 (
      /* rank := rank - RankFilter( FILTERS[i] ); */
      t_5 = GF_RankFilter;
      t_7 = GC_FILTERS;
-     CHECK_BOUND( t_7, "FILTERS" );
-     C_ELM_LIST_FPL( t_6, t_7, l_i );
+     CHECK_BOUND( t_7, "FILTERS" )
+     C_ELM_LIST_FPL( t_6, t_7, l_i )
      t_4 = CALL_1ARGS( t_5, t_6 );
-     CHECK_FUNC_RESULT( t_4 );
-     C_DIFF_FIA( t_3, l_rank, t_4 );
+     CHECK_FUNC_RESULT( t_4 )
+     C_DIFF_FIA( t_3, l_rank, t_4 )
      l_rank = t_3;
      
     }
@@ -2375,17 +2375,17 @@ static Obj  HdlrFunc7 (
     /* elif i in NUMBERS_PROPERTY_GETTERS then */
     else {
      t_4 = GC_NUMBERS__PROPERTY__GETTERS;
-     CHECK_BOUND( t_4, "NUMBERS_PROPERTY_GETTERS" );
+     CHECK_BOUND( t_4, "NUMBERS_PROPERTY_GETTERS" )
      t_3 = (Obj)(UInt)(IN( l_i, t_4 ));
      if ( t_3 ) {
       
       /* ADD_LIST( props, FILTERS[i] ); */
       t_3 = GF_ADD__LIST;
       t_4 = OBJ_LVAR( 2 );
-      CHECK_BOUND( t_4, "props" );
+      CHECK_BOUND( t_4, "props" )
       t_6 = GC_FILTERS;
-      CHECK_BOUND( t_6, "FILTERS" );
-      C_ELM_LIST_FPL( t_5, t_6, l_i );
+      CHECK_BOUND( t_6, "FILTERS" )
+      C_ELM_LIST_FPL( t_5, t_6, l_i )
       CALL_2ARGS( t_3, t_4, t_5 );
       
      }
@@ -2401,9 +2401,9 @@ static Obj  HdlrFunc7 (
   /* if 0 < LEN_LIST( props ) then */
   t_3 = GF_LEN__LIST;
   t_4 = OBJ_LVAR( 2 );
-  CHECK_BOUND( t_4, "props" );
+  CHECK_BOUND( t_4, "props" )
   t_2 = CALL_1ARGS( t_3, t_4 );
-  CHECK_FUNC_RESULT( t_2 );
+  CHECK_FUNC_RESULT( t_2 )
   t_1 = (Obj)(UInt)(LT( INTOBJ_INT(0), t_2 ));
   if ( t_1 ) {
    
@@ -2427,7 +2427,7 @@ static Obj  HdlrFunc7 (
   end ); */
    t_1 = GF_InstallOtherMethod;
    t_2 = OBJ_LVAR( 1 );
-   CHECK_BOUND( t_2, "getter" );
+   CHECK_BOUND( t_2, "getter" )
    C_NEW_STRING( t_3, 59, "default method requiring categories and checking properties" );
    t_4 = True;
    t_5 = NEW_PLIST( T_PLIST, 1 );
@@ -2491,15 +2491,15 @@ static Obj  HdlrFunc9 (
  t_4 = NEW_PLIST( T_PLIST, 2 );
  SET_LEN_PLIST( t_4, 2 );
  t_5 = GC_IS__OBJECT;
- CHECK_BOUND( t_5, "IS_OBJECT" );
+ CHECK_BOUND( t_5, "IS_OBJECT" )
  SET_ELM_PLIST( t_4, 1, t_5 );
  CHANGED_BAG( t_4 );
  t_5 = GC_IS__OBJECT;
- CHECK_BOUND( t_5, "IS_OBJECT" );
+ CHECK_BOUND( t_5, "IS_OBJECT" )
  SET_ELM_PLIST( t_4, 2, t_5 );
  CHANGED_BAG( t_4 );
  t_5 = GC_DO__NOTHING__SETTER;
- CHECK_BOUND( t_5, "DO_NOTHING_SETTER" );
+ CHECK_BOUND( t_5, "DO_NOTHING_SETTER" )
  CALL_6ARGS( t_1, a_setter, t_2, t_3, t_4, INTOBJ_INT(0), t_5 );
  
  /* return; */
@@ -2539,8 +2539,8 @@ static Obj  HdlrFunc10 (
  /* k := LEN_LIST( list ) + 1; */
  t_3 = GF_LEN__LIST;
  t_2 = CALL_1ARGS( t_3, a_list );
- CHECK_FUNC_RESULT( t_2 );
- C_SUM_FIA( t_1, t_2, INTOBJ_INT(1) );
+ CHECK_FUNC_RESULT( t_2 )
+ C_SUM_FIA( t_1, t_2, INTOBJ_INT(1) )
  l_k = t_1;
  
  /* if k mod 2 = 0 then */
@@ -2549,7 +2549,7 @@ static Obj  HdlrFunc10 (
  if ( t_1 ) {
   
   /* k := k + 1; */
-  C_SUM_FIA( t_1, l_k, INTOBJ_INT(1) );
+  C_SUM_FIA( t_1, l_k, INTOBJ_INT(1) )
   l_k = t_1;
   
  }
@@ -2560,23 +2560,23 @@ static Obj  HdlrFunc10 (
  
  /* while i + 2 < k od */
  while ( 1 ) {
-  C_SUM_FIA( t_2, l_i, INTOBJ_INT(2) );
+  C_SUM_FIA( t_2, l_i, INTOBJ_INT(2) )
   t_1 = (Obj)(UInt)(LT( t_2, l_k ));
   if ( ! t_1 ) break;
   
   /* j := 2 * QUO_INT( (i + k + 2), 4 ) - 1; */
   t_4 = GF_QUO__INT;
-  C_SUM_FIA( t_6, l_i, l_k );
-  C_SUM_FIA( t_5, t_6, INTOBJ_INT(2) );
+  C_SUM_FIA( t_6, l_i, l_k )
+  C_SUM_FIA( t_5, t_6, INTOBJ_INT(2) )
   t_3 = CALL_2ARGS( t_4, t_5, INTOBJ_INT(4) );
-  CHECK_FUNC_RESULT( t_3 );
-  C_PROD_FIA( t_2, INTOBJ_INT(2), t_3 );
-  C_DIFF_FIA( t_1, t_2, INTOBJ_INT(1) );
+  CHECK_FUNC_RESULT( t_3 )
+  C_PROD_FIA( t_2, INTOBJ_INT(2), t_3 )
+  C_DIFF_FIA( t_1, t_2, INTOBJ_INT(1) )
   l_j = t_1;
   
   /* if list[j] < elm then */
-  CHECK_INT_POS( l_j );
-  C_ELM_LIST_FPL( t_2, a_list, l_j );
+  CHECK_INT_POS( l_j )
+  C_ELM_LIST_FPL( t_2, a_list, l_j )
   t_1 = (Obj)(UInt)(LT( t_2, a_elm ));
   if ( t_1 ) {
    
@@ -2628,8 +2628,8 @@ static Obj  HdlrFunc12 (
  /* if not IsPrimeInt( key ) then */
  t_4 = GF_IsPrimeInt;
  t_3 = CALL_1ARGS( t_4, a_key );
- CHECK_FUNC_RESULT( t_3 );
- CHECK_BOOL( t_3 );
+ CHECK_FUNC_RESULT( t_3 )
+ CHECK_BOOL( t_3 )
  t_2 = (Obj)(UInt)(t_3 != False);
  t_1 = (Obj)(UInt)( ! ((Int)t_2) );
  if ( t_1 ) {
@@ -2637,7 +2637,7 @@ static Obj  HdlrFunc12 (
   /* Error( name, ": <p> must be a prime" ); */
   t_1 = GF_Error;
   t_2 = OBJ_LVAR_1UP( 1 );
-  CHECK_BOUND( t_2, "name" );
+  CHECK_BOUND( t_2, "name" )
   C_NEW_STRING( t_3, 21, ": <p> must be a prime" );
   CALL_2ARGS( t_1, t_2, t_3 );
   
@@ -2706,33 +2706,33 @@ static Obj  HdlrFunc14 (
  
  /* keytest( key ); */
  t_1 = OBJ_LVAR_1UP( 2 );
- CHECK_BOUND( t_1, "keytest" );
- CHECK_FUNC( t_1 );
+ CHECK_BOUND( t_1, "keytest" )
+ CHECK_FUNC( t_1 )
  CALL_1ARGS( t_1, a_key );
  
  /* known := attr( D ); */
  t_2 = OBJ_LVAR_1UP( 4 );
- CHECK_BOUND( t_2, "attr" );
- CHECK_FUNC( t_2 );
+ CHECK_BOUND( t_2, "attr" )
+ CHECK_FUNC( t_2 )
  t_1 = CALL_1ARGS( t_2, a_D );
- CHECK_FUNC_RESULT( t_1 );
+ CHECK_FUNC_RESULT( t_1 )
  l_known = t_1;
  
  /* i := PositionSortedOddPositions( known, key ); */
  t_2 = GF_PositionSortedOddPositions;
  t_1 = CALL_2ARGS( t_2, l_known, a_key );
- CHECK_FUNC_RESULT( t_1 );
+ CHECK_FUNC_RESULT( t_1 )
  l_i = t_1;
  
  /* if LEN_LIST( known ) < i or known[i] <> key then */
  t_4 = GF_LEN__LIST;
  t_3 = CALL_1ARGS( t_4, l_known );
- CHECK_FUNC_RESULT( t_3 );
+ CHECK_FUNC_RESULT( t_3 )
  t_2 = (Obj)(UInt)(LT( t_3, l_i ));
  t_1 = t_2;
  if ( ! t_1 ) {
-  CHECK_INT_POS( l_i );
-  C_ELM_LIST_FPL( t_4, l_known, l_i );
+  CHECK_INT_POS( l_i )
+  C_ELM_LIST_FPL( t_4, l_known, l_i )
   t_3 = (Obj)(UInt)( ! EQ( t_4, a_key ));
   t_1 = t_3;
  }
@@ -2740,60 +2740,60 @@ static Obj  HdlrFunc14 (
   
   /* erg := oper( D, key ); */
   t_2 = OBJ_LVAR_1UP( 3 );
-  CHECK_BOUND( t_2, "oper" );
-  CHECK_FUNC( t_2 );
+  CHECK_BOUND( t_2, "oper" )
+  CHECK_FUNC( t_2 )
   t_1 = CALL_2ARGS( t_2, a_D, a_key );
-  CHECK_FUNC_RESULT( t_1 );
+  CHECK_FUNC_RESULT( t_1 )
   l_erg = t_1;
   
   /* i := PositionSortedOddPositions( known, key ); */
   t_2 = GF_PositionSortedOddPositions;
   t_1 = CALL_2ARGS( t_2, l_known, a_key );
-  CHECK_FUNC_RESULT( t_1 );
+  CHECK_FUNC_RESULT( t_1 )
   l_i = t_1;
   
   /* if LEN_LIST( known ) < i or known[i] <> key then */
   t_4 = GF_LEN__LIST;
   t_3 = CALL_1ARGS( t_4, l_known );
-  CHECK_FUNC_RESULT( t_3 );
+  CHECK_FUNC_RESULT( t_3 )
   t_2 = (Obj)(UInt)(LT( t_3, l_i ));
   t_1 = t_2;
   if ( ! t_1 ) {
-   CHECK_INT_POS( l_i );
-   C_ELM_LIST_FPL( t_4, l_known, l_i );
+   CHECK_INT_POS( l_i )
+   C_ELM_LIST_FPL( t_4, l_known, l_i )
    t_3 = (Obj)(UInt)( ! EQ( t_4, a_key ));
    t_1 = t_3;
   }
   if ( t_1 ) {
    
    /* known{[ i + 2 .. LEN_LIST( known ) + 2 ]} := known{[ i .. LEN_LIST( known ) ]}; */
-   C_SUM_FIA( t_2, l_i, INTOBJ_INT(2) );
+   C_SUM_FIA( t_2, l_i, INTOBJ_INT(2) )
    t_5 = GF_LEN__LIST;
    t_4 = CALL_1ARGS( t_5, l_known );
-   CHECK_FUNC_RESULT( t_4 );
-   C_SUM_FIA( t_3, t_4, INTOBJ_INT(2) );
+   CHECK_FUNC_RESULT( t_4 )
+   C_SUM_FIA( t_3, t_4, INTOBJ_INT(2) )
    t_1 = Range2Check( t_2, t_3 );
    t_5 = GF_LEN__LIST;
    t_4 = CALL_1ARGS( t_5, l_known );
-   CHECK_FUNC_RESULT( t_4 );
+   CHECK_FUNC_RESULT( t_4 )
    t_3 = Range2Check( l_i, t_4 );
    t_2 = ElmsListCheck( l_known, t_3 );
    AsssListCheck( l_known, t_1, t_2 );
    
    /* known[i] := IMMUTABLE_COPY_OBJ( key ); */
-   CHECK_INT_POS( l_i );
+   CHECK_INT_POS( l_i )
    t_2 = GF_IMMUTABLE__COPY__OBJ;
    t_1 = CALL_1ARGS( t_2, a_key );
-   CHECK_FUNC_RESULT( t_1 );
-   C_ASS_LIST_FPL( l_known, l_i, t_1 );
+   CHECK_FUNC_RESULT( t_1 )
+   C_ASS_LIST_FPL( l_known, l_i, t_1 )
    
    /* known[i + 1] := IMMUTABLE_COPY_OBJ( erg ); */
-   C_SUM_FIA( t_1, l_i, INTOBJ_INT(1) );
-   CHECK_INT_POS( t_1 );
+   C_SUM_FIA( t_1, l_i, INTOBJ_INT(1) )
+   CHECK_INT_POS( t_1 )
    t_3 = GF_IMMUTABLE__COPY__OBJ;
    t_2 = CALL_1ARGS( t_3, l_erg );
-   CHECK_FUNC_RESULT( t_2 );
-   C_ASS_LIST_FPL( l_known, t_1, t_2 );
+   CHECK_FUNC_RESULT( t_2 )
+   C_ASS_LIST_FPL( l_known, t_1, t_2 )
    
   }
   /* fi */
@@ -2802,9 +2802,9 @@ static Obj  HdlrFunc14 (
  /* fi */
  
  /* return known[i + 1]; */
- C_SUM_FIA( t_2, l_i, INTOBJ_INT(1) );
- CHECK_INT_POS( t_2 );
- C_ELM_LIST_FPL( t_1, l_known, t_2 );
+ C_SUM_FIA( t_2, l_i, INTOBJ_INT(1) )
+ CHECK_INT_POS( t_2 )
+ C_ELM_LIST_FPL( t_1, l_known, t_2 )
  RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
@@ -2838,43 +2838,43 @@ static Obj  HdlrFunc15 (
  
  /* keytest( key ); */
  t_1 = OBJ_LVAR_1UP( 2 );
- CHECK_BOUND( t_1, "keytest" );
- CHECK_FUNC( t_1 );
+ CHECK_BOUND( t_1, "keytest" )
+ CHECK_FUNC( t_1 )
  CALL_1ARGS( t_1, a_key );
  
  /* known := attr( D ); */
  t_2 = OBJ_LVAR_1UP( 4 );
- CHECK_BOUND( t_2, "attr" );
- CHECK_FUNC( t_2 );
+ CHECK_BOUND( t_2, "attr" )
+ CHECK_FUNC( t_2 )
  t_1 = CALL_1ARGS( t_2, a_D );
- CHECK_FUNC_RESULT( t_1 );
+ CHECK_FUNC_RESULT( t_1 )
  l_known = t_1;
  
  /* i := PositionSortedOddPositions( known, key ); */
  t_2 = GF_PositionSortedOddPositions;
  t_1 = CALL_2ARGS( t_2, l_known, a_key );
- CHECK_FUNC_RESULT( t_1 );
+ CHECK_FUNC_RESULT( t_1 )
  l_i = t_1;
  
  /* return i <= LEN_LIST( known ) and known[i] = key; */
  t_4 = GF_LEN__LIST;
  t_3 = CALL_1ARGS( t_4, l_known );
- CHECK_FUNC_RESULT( t_3 );
+ CHECK_FUNC_RESULT( t_3 )
  t_2 = (LT( t_3, l_i ) ?  False : True);
  if ( t_2 == False ) {
   t_1 = t_2;
  }
  else if ( t_2 == True ) {
-  CHECK_INT_POS( l_i );
-  C_ELM_LIST_FPL( t_4, l_known, l_i );
+  CHECK_INT_POS( l_i )
+  C_ELM_LIST_FPL( t_4, l_known, l_i )
   t_3 = (EQ( t_4, a_key ) ? True : False);
   t_1 = t_3;
  }
  else {
-  CHECK_FUNC( t_2 );
-  C_ELM_LIST_FPL( t_5, l_known, l_i );
+  CHECK_FUNC( t_2 )
+  C_ELM_LIST_FPL( t_5, l_known, l_i )
   t_4 = (EQ( t_5, a_key ) ? True : False);
-  CHECK_FUNC( t_4 );
+  CHECK_FUNC( t_4 )
   t_1 = NewAndFilter( t_2, t_4 );
  }
  RES_BRK_CURR_STAT();
@@ -2911,66 +2911,66 @@ static Obj  HdlrFunc16 (
  
  /* keytest( key ); */
  t_1 = OBJ_LVAR_1UP( 2 );
- CHECK_BOUND( t_1, "keytest" );
- CHECK_FUNC( t_1 );
+ CHECK_BOUND( t_1, "keytest" )
+ CHECK_FUNC( t_1 )
  CALL_1ARGS( t_1, a_key );
  
  /* known := attr( D ); */
  t_2 = OBJ_LVAR_1UP( 4 );
- CHECK_BOUND( t_2, "attr" );
- CHECK_FUNC( t_2 );
+ CHECK_BOUND( t_2, "attr" )
+ CHECK_FUNC( t_2 )
  t_1 = CALL_1ARGS( t_2, a_D );
- CHECK_FUNC_RESULT( t_1 );
+ CHECK_FUNC_RESULT( t_1 )
  l_known = t_1;
  
  /* i := PositionSortedOddPositions( known, key ); */
  t_2 = GF_PositionSortedOddPositions;
  t_1 = CALL_2ARGS( t_2, l_known, a_key );
- CHECK_FUNC_RESULT( t_1 );
+ CHECK_FUNC_RESULT( t_1 )
  l_i = t_1;
  
  /* if LEN_LIST( known ) < i or known[i] <> key then */
  t_4 = GF_LEN__LIST;
  t_3 = CALL_1ARGS( t_4, l_known );
- CHECK_FUNC_RESULT( t_3 );
+ CHECK_FUNC_RESULT( t_3 )
  t_2 = (Obj)(UInt)(LT( t_3, l_i ));
  t_1 = t_2;
  if ( ! t_1 ) {
-  CHECK_INT_POS( l_i );
-  C_ELM_LIST_FPL( t_4, l_known, l_i );
+  CHECK_INT_POS( l_i )
+  C_ELM_LIST_FPL( t_4, l_known, l_i )
   t_3 = (Obj)(UInt)( ! EQ( t_4, a_key ));
   t_1 = t_3;
  }
  if ( t_1 ) {
   
   /* known{[ i + 2 .. LEN_LIST( known ) + 2 ]} := known{[ i .. LEN_LIST( known ) ]}; */
-  C_SUM_FIA( t_2, l_i, INTOBJ_INT(2) );
+  C_SUM_FIA( t_2, l_i, INTOBJ_INT(2) )
   t_5 = GF_LEN__LIST;
   t_4 = CALL_1ARGS( t_5, l_known );
-  CHECK_FUNC_RESULT( t_4 );
-  C_SUM_FIA( t_3, t_4, INTOBJ_INT(2) );
+  CHECK_FUNC_RESULT( t_4 )
+  C_SUM_FIA( t_3, t_4, INTOBJ_INT(2) )
   t_1 = Range2Check( t_2, t_3 );
   t_5 = GF_LEN__LIST;
   t_4 = CALL_1ARGS( t_5, l_known );
-  CHECK_FUNC_RESULT( t_4 );
+  CHECK_FUNC_RESULT( t_4 )
   t_3 = Range2Check( l_i, t_4 );
   t_2 = ElmsListCheck( l_known, t_3 );
   AsssListCheck( l_known, t_1, t_2 );
   
   /* known[i] := IMMUTABLE_COPY_OBJ( key ); */
-  CHECK_INT_POS( l_i );
+  CHECK_INT_POS( l_i )
   t_2 = GF_IMMUTABLE__COPY__OBJ;
   t_1 = CALL_1ARGS( t_2, a_key );
-  CHECK_FUNC_RESULT( t_1 );
-  C_ASS_LIST_FPL( l_known, l_i, t_1 );
+  CHECK_FUNC_RESULT( t_1 )
+  C_ASS_LIST_FPL( l_known, l_i, t_1 )
   
   /* known[i + 1] := IMMUTABLE_COPY_OBJ( obj ); */
-  C_SUM_FIA( t_1, l_i, INTOBJ_INT(1) );
-  CHECK_INT_POS( t_1 );
+  C_SUM_FIA( t_1, l_i, INTOBJ_INT(1) )
+  CHECK_INT_POS( t_1 )
   t_3 = GF_IMMUTABLE__COPY__OBJ;
   t_2 = CALL_1ARGS( t_3, a_obj );
-  CHECK_FUNC_RESULT( t_2 );
-  C_ASS_LIST_FPL( l_known, t_1, t_2 );
+  CHECK_FUNC_RESULT( t_2 )
+  C_ASS_LIST_FPL( l_known, t_1, t_2 )
   
  }
  /* fi */
@@ -3014,7 +3014,7 @@ static Obj  HdlrFunc11 (
  
  /* if keytest = "prime" then */
  t_2 = OBJ_LVAR( 2 );
- CHECK_BOUND( t_2, "keytest" );
+ CHECK_BOUND( t_2, "keytest" )
  C_NEW_STRING( t_3, 5, "prime" );
  t_1 = (Obj)(UInt)(EQ( t_2, t_3 ));
  if ( t_1 ) {
@@ -3041,9 +3041,9 @@ static Obj  HdlrFunc11 (
  /* str := SHALLOW_COPY_OBJ( name ); */
  t_2 = GF_SHALLOW__COPY__OBJ;
  t_3 = OBJ_LVAR( 1 );
- CHECK_BOUND( t_3, "name" );
+ CHECK_BOUND( t_3, "name" )
  t_1 = CALL_1ARGS( t_2, t_3 );
- CHECK_FUNC_RESULT( t_1 );
+ CHECK_FUNC_RESULT( t_1 )
  l_str = t_1;
  
  /* APPEND_LIST_INTR( str, "Op" ); */
@@ -3064,7 +3064,7 @@ static Obj  HdlrFunc11 (
  /* oper := VALUE_GLOBAL( str ); */
  t_2 = GF_VALUE__GLOBAL;
  t_1 = CALL_1ARGS( t_2, l_str );
- CHECK_FUNC_RESULT( t_1 );
+ CHECK_FUNC_RESULT( t_1 )
  ASS_LVAR( 3, t_1 );
  
  /* str := "Computed"; */
@@ -3074,7 +3074,7 @@ static Obj  HdlrFunc11 (
  /* APPEND_LIST_INTR( str, name ); */
  t_1 = GF_APPEND__LIST__INTR;
  t_2 = OBJ_LVAR( 1 );
- CHECK_BOUND( t_2, "name" );
+ CHECK_BOUND( t_2, "name" )
  CALL_2ARGS( t_1, l_str, t_2 );
  
  /* APPEND_LIST_INTR( str, "s" ); */
@@ -3090,7 +3090,7 @@ static Obj  HdlrFunc11 (
  /* attr := VALUE_GLOBAL( str ); */
  t_2 = GF_VALUE__GLOBAL;
  t_1 = CALL_1ARGS( t_2, l_str );
- CHECK_FUNC_RESULT( t_1 );
+ CHECK_FUNC_RESULT( t_1 )
  ASS_LVAR( 4, t_1 );
  
  /* InstallMethod( attr, "default method", true, [ domreq ], 0, function ( D )
@@ -3098,7 +3098,7 @@ static Obj  HdlrFunc11 (
   end ); */
  t_1 = GF_InstallMethod;
  t_2 = OBJ_LVAR( 4 );
- CHECK_BOUND( t_2, "attr" );
+ CHECK_BOUND( t_2, "attr" )
  C_NEW_STRING( t_3, 14, "default method" );
  t_4 = True;
  t_5 = NEW_PLIST( T_PLIST, 1 );
@@ -3118,7 +3118,7 @@ static Obj  HdlrFunc11 (
  /* DeclareOperation( name, [ domreq, keyreq ] ); */
  t_1 = GF_DeclareOperation;
  t_2 = OBJ_LVAR( 1 );
- CHECK_BOUND( t_2, "name" );
+ CHECK_BOUND( t_2, "name" )
  t_3 = NEW_PLIST( T_PLIST, 2 );
  SET_LEN_PLIST( t_3, 2 );
  SET_ELM_PLIST( t_3, 1, a_domreq );
@@ -3130,12 +3130,12 @@ static Obj  HdlrFunc11 (
  /* ADD_LIST( WRAPPER_OPERATIONS, VALUE_GLOBAL( name ) ); */
  t_1 = GF_ADD__LIST;
  t_2 = GC_WRAPPER__OPERATIONS;
- CHECK_BOUND( t_2, "WRAPPER_OPERATIONS" );
+ CHECK_BOUND( t_2, "WRAPPER_OPERATIONS" )
  t_4 = GF_VALUE__GLOBAL;
  t_5 = OBJ_LVAR( 1 );
- CHECK_BOUND( t_5, "name" );
+ CHECK_BOUND( t_5, "name" )
  t_3 = CALL_1ARGS( t_4, t_5 );
- CHECK_FUNC_RESULT( t_3 );
+ CHECK_FUNC_RESULT( t_3 )
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* InstallOtherMethod( VALUE_GLOBAL( name ), "default method", true, [ domreq, keyreq ], 0, function ( D, key )
@@ -3157,9 +3157,9 @@ static Obj  HdlrFunc11 (
  t_1 = GF_InstallOtherMethod;
  t_3 = GF_VALUE__GLOBAL;
  t_4 = OBJ_LVAR( 1 );
- CHECK_BOUND( t_4, "name" );
+ CHECK_BOUND( t_4, "name" )
  t_2 = CALL_1ARGS( t_3, t_4 );
- CHECK_FUNC_RESULT( t_2 );
+ CHECK_FUNC_RESULT( t_2 )
  C_NEW_STRING( t_3, 14, "default method" );
  t_4 = True;
  t_5 = NEW_PLIST( T_PLIST, 2 );
@@ -3185,7 +3185,7 @@ static Obj  HdlrFunc11 (
  /* APPEND_LIST_INTR( str, name ); */
  t_1 = GF_APPEND__LIST__INTR;
  t_2 = OBJ_LVAR( 1 );
- CHECK_BOUND( t_2, "name" );
+ CHECK_BOUND( t_2, "name" )
  CALL_2ARGS( t_1, l_str, t_2 );
  
  /* DeclareOperation( str, [ domreq, keyreq ] ); */
@@ -3208,7 +3208,7 @@ static Obj  HdlrFunc11 (
  t_1 = GF_InstallOtherMethod;
  t_3 = GF_VALUE__GLOBAL;
  t_2 = CALL_1ARGS( t_3, l_str );
- CHECK_FUNC_RESULT( t_2 );
+ CHECK_FUNC_RESULT( t_2 )
  C_NEW_STRING( t_3, 14, "default method" );
  t_4 = True;
  t_5 = NEW_PLIST( T_PLIST, 2 );
@@ -3234,7 +3234,7 @@ static Obj  HdlrFunc11 (
  /* APPEND_LIST_INTR( str, name ); */
  t_1 = GF_APPEND__LIST__INTR;
  t_2 = OBJ_LVAR( 1 );
- CHECK_BOUND( t_2, "name" );
+ CHECK_BOUND( t_2, "name" )
  CALL_2ARGS( t_1, l_str, t_2 );
  
  /* DeclareOperation( str, [ domreq, keyreq, IS_OBJECT ] ); */
@@ -3246,7 +3246,7 @@ static Obj  HdlrFunc11 (
  SET_ELM_PLIST( t_2, 2, a_keyreq );
  CHANGED_BAG( t_2 );
  t_3 = GC_IS__OBJECT;
- CHECK_BOUND( t_3, "IS_OBJECT" );
+ CHECK_BOUND( t_3, "IS_OBJECT" )
  SET_ELM_PLIST( t_2, 3, t_3 );
  CHANGED_BAG( t_2 );
  CALL_2ARGS( t_1, l_str, t_2 );
@@ -3266,7 +3266,7 @@ static Obj  HdlrFunc11 (
  t_1 = GF_InstallOtherMethod;
  t_3 = GF_VALUE__GLOBAL;
  t_2 = CALL_1ARGS( t_3, l_str );
- CHECK_FUNC_RESULT( t_2 );
+ CHECK_FUNC_RESULT( t_2 )
  C_NEW_STRING( t_3, 14, "default method" );
  t_4 = True;
  t_5 = NEW_PLIST( T_PLIST, 3 );
@@ -3276,7 +3276,7 @@ static Obj  HdlrFunc11 (
  SET_ELM_PLIST( t_5, 2, a_keyreq );
  CHANGED_BAG( t_5 );
  t_6 = GC_IS__OBJECT;
- CHECK_BOUND( t_6, "IS_OBJECT" );
+ CHECK_BOUND( t_6, "IS_OBJECT" )
  SET_ELM_PLIST( t_5, 3, t_6 );
  CHANGED_BAG( t_5 );
  t_6 = NewFunction( NameFunc[16], NargFunc[16], NamsFunc[16], HdlrFunc16 );
@@ -3338,9 +3338,9 @@ static Obj  HdlrFunc18 (
  /* for i in [ 1 .. LEN_LIST( reqs ) ] do */
  t_6 = GF_LEN__LIST;
  t_7 = OBJ_LVAR_1UP( 2 );
- CHECK_BOUND( t_7, "reqs" );
+ CHECK_BOUND( t_7, "reqs" )
  t_5 = CALL_1ARGS( t_6, t_7 );
- CHECK_FUNC_RESULT( t_5 );
+ CHECK_FUNC_RESULT( t_5 )
  t_4 = Range2Check( INTOBJ_INT(1), t_5 );
  if ( IS_SMALL_LIST(t_4) ) {
   t_3 = (Obj)(UInt)1;
@@ -3365,37 +3365,37 @@ static Obj  HdlrFunc18 (
   
   /* re := re or IsBound( cond[i] ) and not Tester( cond[i] )( arg[i] ) and cond[i]( arg[i] ) and Tester( cond[i] )( arg[i] ); */
   t_7 = OBJ_LVAR_1UP( 4 );
-  CHECK_BOUND( t_7, "re" );
-  CHECK_BOOL( t_7 );
+  CHECK_BOUND( t_7, "re" )
+  CHECK_BOOL( t_7 )
   t_6 = (Obj)(UInt)(t_7 != False);
   t_5 = (t_6 ? True : False);
   if ( t_5 == False ) {
    t_12 = OBJ_LVAR_1UP( 3 );
-   CHECK_BOUND( t_12, "cond" );
+   CHECK_BOUND( t_12, "cond" )
    t_13 = OBJ_LVAR_1UP( 5 );
-   CHECK_BOUND( t_13, "i" );
-   CHECK_INT_POS( t_13 );
+   CHECK_BOUND( t_13, "i" )
+   CHECK_INT_POS( t_13 )
    t_11 = C_ISB_LIST( t_12, t_13 );
    t_10 = (Obj)(UInt)(t_11 != False);
    t_9 = t_10;
    if ( t_9 ) {
     t_15 = GF_Tester;
     t_17 = OBJ_LVAR_1UP( 3 );
-    CHECK_BOUND( t_17, "cond" );
+    CHECK_BOUND( t_17, "cond" )
     t_18 = OBJ_LVAR_1UP( 5 );
-    CHECK_BOUND( t_18, "i" );
-    CHECK_INT_POS( t_18 );
-    C_ELM_LIST_FPL( t_16, t_17, t_18 );
+    CHECK_BOUND( t_18, "i" )
+    CHECK_INT_POS( t_18 )
+    C_ELM_LIST_FPL( t_16, t_17, t_18 )
     t_14 = CALL_1ARGS( t_15, t_16 );
-    CHECK_FUNC_RESULT( t_14 );
-    CHECK_FUNC( t_14 );
+    CHECK_FUNC_RESULT( t_14 )
+    CHECK_FUNC( t_14 )
     t_16 = OBJ_LVAR_1UP( 5 );
-    CHECK_BOUND( t_16, "i" );
-    CHECK_INT_POS( t_16 );
-    C_ELM_LIST_FPL( t_15, a_arg, t_16 );
+    CHECK_BOUND( t_16, "i" )
+    CHECK_INT_POS( t_16 )
+    C_ELM_LIST_FPL( t_15, a_arg, t_16 )
     t_13 = CALL_1ARGS( t_14, t_15 );
-    CHECK_FUNC_RESULT( t_13 );
-    CHECK_BOOL( t_13 );
+    CHECK_FUNC_RESULT( t_13 )
+    CHECK_BOOL( t_13 )
     t_12 = (Obj)(UInt)(t_13 != False);
     t_11 = (Obj)(UInt)( ! ((Int)t_12) );
     t_9 = t_11;
@@ -3403,19 +3403,19 @@ static Obj  HdlrFunc18 (
    t_8 = t_9;
    if ( t_8 ) {
     t_13 = OBJ_LVAR_1UP( 3 );
-    CHECK_BOUND( t_13, "cond" );
+    CHECK_BOUND( t_13, "cond" )
     t_14 = OBJ_LVAR_1UP( 5 );
-    CHECK_BOUND( t_14, "i" );
-    CHECK_INT_POS( t_14 );
-    C_ELM_LIST_FPL( t_12, t_13, t_14 );
-    CHECK_FUNC( t_12 );
+    CHECK_BOUND( t_14, "i" )
+    CHECK_INT_POS( t_14 )
+    C_ELM_LIST_FPL( t_12, t_13, t_14 )
+    CHECK_FUNC( t_12 )
     t_14 = OBJ_LVAR_1UP( 5 );
-    CHECK_BOUND( t_14, "i" );
-    CHECK_INT_POS( t_14 );
-    C_ELM_LIST_FPL( t_13, a_arg, t_14 );
+    CHECK_BOUND( t_14, "i" )
+    CHECK_INT_POS( t_14 )
+    C_ELM_LIST_FPL( t_13, a_arg, t_14 )
     t_11 = CALL_1ARGS( t_12, t_13 );
-    CHECK_FUNC_RESULT( t_11 );
-    CHECK_BOOL( t_11 );
+    CHECK_FUNC_RESULT( t_11 )
+    CHECK_BOOL( t_11 )
     t_10 = (Obj)(UInt)(t_11 != False);
     t_8 = t_10;
    }
@@ -3423,21 +3423,21 @@ static Obj  HdlrFunc18 (
    if ( t_7 ) {
     t_12 = GF_Tester;
     t_14 = OBJ_LVAR_1UP( 3 );
-    CHECK_BOUND( t_14, "cond" );
+    CHECK_BOUND( t_14, "cond" )
     t_15 = OBJ_LVAR_1UP( 5 );
-    CHECK_BOUND( t_15, "i" );
-    CHECK_INT_POS( t_15 );
-    C_ELM_LIST_FPL( t_13, t_14, t_15 );
+    CHECK_BOUND( t_15, "i" )
+    CHECK_INT_POS( t_15 )
+    C_ELM_LIST_FPL( t_13, t_14, t_15 )
     t_11 = CALL_1ARGS( t_12, t_13 );
-    CHECK_FUNC_RESULT( t_11 );
-    CHECK_FUNC( t_11 );
+    CHECK_FUNC_RESULT( t_11 )
+    CHECK_FUNC( t_11 )
     t_13 = OBJ_LVAR_1UP( 5 );
-    CHECK_BOUND( t_13, "i" );
-    CHECK_INT_POS( t_13 );
-    C_ELM_LIST_FPL( t_12, a_arg, t_13 );
+    CHECK_BOUND( t_13, "i" )
+    CHECK_INT_POS( t_13 )
+    C_ELM_LIST_FPL( t_12, a_arg, t_13 )
     t_10 = CALL_1ARGS( t_11, t_12 );
-    CHECK_FUNC_RESULT( t_10 );
-    CHECK_BOOL( t_10 );
+    CHECK_FUNC_RESULT( t_10 )
+    CHECK_BOOL( t_10 )
     t_9 = (Obj)(UInt)(t_10 != False);
     t_7 = t_9;
    }
@@ -3450,17 +3450,17 @@ static Obj  HdlrFunc18 (
  
  /* if re then */
  t_2 = OBJ_LVAR_1UP( 4 );
- CHECK_BOUND( t_2, "re" );
- CHECK_BOOL( t_2 );
+ CHECK_BOUND( t_2, "re" )
+ CHECK_BOOL( t_2 )
  t_1 = (Obj)(UInt)(t_2 != False);
  if ( t_1 ) {
   
   /* return CallFuncList( oper, arg ); */
   t_2 = GF_CallFuncList;
   t_3 = OBJ_LVAR_1UP( 1 );
-  CHECK_BOUND( t_3, "oper" );
+  CHECK_BOUND( t_3, "oper" )
   t_1 = CALL_2ARGS( t_2, t_3, a_arg );
-  CHECK_FUNC_RESULT( t_1 );
+  CHECK_FUNC_RESULT( t_1 )
   RES_BRK_CURR_STAT();
   SWITCH_TO_OLD_FRAME(oldFrame);
   return t_1;
@@ -3472,7 +3472,7 @@ static Obj  HdlrFunc18 (
   
   /* return TRY_NEXT_METHOD; */
   t_1 = GC_TRY__NEXT__METHOD;
-  CHECK_BOUND( t_1, "TRY_NEXT_METHOD" );
+  CHECK_BOUND( t_1, "TRY_NEXT_METHOD" )
   RES_BRK_CURR_STAT();
   SWITCH_TO_OLD_FRAME(oldFrame);
   return t_1;
@@ -3522,12 +3522,12 @@ static Obj  HdlrFunc17 (
  /* if LEN_LIST( arg ) = 5 then */
  t_3 = GF_LEN__LIST;
  t_2 = CALL_1ARGS( t_3, a_arg );
- CHECK_FUNC_RESULT( t_2 );
+ CHECK_FUNC_RESULT( t_2 )
  t_1 = (Obj)(UInt)(EQ( t_2, INTOBJ_INT(5) ));
  if ( t_1 ) {
   
   /* oper := arg[1]; */
-  C_ELM_LIST_FPL( t_1, a_arg, INTOBJ_INT(1) );
+  C_ELM_LIST_FPL( t_1, a_arg, INTOBJ_INT(1) )
   ASS_LVAR( 1, t_1 );
   
   /* info := " fallback method to test conditions"; */
@@ -3535,19 +3535,19 @@ static Obj  HdlrFunc17 (
   l_info = t_1;
   
   /* fampred := arg[2]; */
-  C_ELM_LIST_FPL( t_1, a_arg, INTOBJ_INT(2) );
+  C_ELM_LIST_FPL( t_1, a_arg, INTOBJ_INT(2) )
   l_fampred = t_1;
   
   /* reqs := arg[3]; */
-  C_ELM_LIST_FPL( t_1, a_arg, INTOBJ_INT(3) );
+  C_ELM_LIST_FPL( t_1, a_arg, INTOBJ_INT(3) )
   ASS_LVAR( 2, t_1 );
   
   /* cond := arg[4]; */
-  C_ELM_LIST_FPL( t_1, a_arg, INTOBJ_INT(4) );
+  C_ELM_LIST_FPL( t_1, a_arg, INTOBJ_INT(4) )
   ASS_LVAR( 3, t_1 );
   
   /* val := arg[5]; */
-  C_ELM_LIST_FPL( t_1, a_arg, INTOBJ_INT(5) );
+  C_ELM_LIST_FPL( t_1, a_arg, INTOBJ_INT(5) )
   l_val = t_1;
   
  }
@@ -3556,32 +3556,32 @@ static Obj  HdlrFunc17 (
  else {
   t_3 = GF_LEN__LIST;
   t_2 = CALL_1ARGS( t_3, a_arg );
-  CHECK_FUNC_RESULT( t_2 );
+  CHECK_FUNC_RESULT( t_2 )
   t_1 = (Obj)(UInt)(EQ( t_2, INTOBJ_INT(6) ));
   if ( t_1 ) {
    
    /* oper := arg[1]; */
-   C_ELM_LIST_FPL( t_1, a_arg, INTOBJ_INT(1) );
+   C_ELM_LIST_FPL( t_1, a_arg, INTOBJ_INT(1) )
    ASS_LVAR( 1, t_1 );
    
    /* info := arg[2]; */
-   C_ELM_LIST_FPL( t_1, a_arg, INTOBJ_INT(2) );
+   C_ELM_LIST_FPL( t_1, a_arg, INTOBJ_INT(2) )
    l_info = t_1;
    
    /* fampred := arg[3]; */
-   C_ELM_LIST_FPL( t_1, a_arg, INTOBJ_INT(3) );
+   C_ELM_LIST_FPL( t_1, a_arg, INTOBJ_INT(3) )
    l_fampred = t_1;
    
    /* reqs := arg[4]; */
-   C_ELM_LIST_FPL( t_1, a_arg, INTOBJ_INT(4) );
+   C_ELM_LIST_FPL( t_1, a_arg, INTOBJ_INT(4) )
    ASS_LVAR( 2, t_1 );
    
    /* cond := arg[5]; */
-   C_ELM_LIST_FPL( t_1, a_arg, INTOBJ_INT(5) );
+   C_ELM_LIST_FPL( t_1, a_arg, INTOBJ_INT(5) )
    ASS_LVAR( 3, t_1 );
    
    /* val := arg[6]; */
-   C_ELM_LIST_FPL( t_1, a_arg, INTOBJ_INT(6) );
+   C_ELM_LIST_FPL( t_1, a_arg, INTOBJ_INT(6) )
    l_val = t_1;
    
   }
@@ -3600,7 +3600,7 @@ static Obj  HdlrFunc17 (
  
  /* for i in reqs do */
  t_4 = OBJ_LVAR( 2 );
- CHECK_BOUND( t_4, "reqs" );
+ CHECK_BOUND( t_4, "reqs" )
  if ( IS_SMALL_LIST(t_4) ) {
   t_3 = (Obj)(UInt)1;
   t_1 = INTOBJ_INT(1);
@@ -3623,19 +3623,19 @@ static Obj  HdlrFunc17 (
   ASS_LVAR( 5, t_2 );
   
   /* val := val - SIZE_FLAGS( WITH_HIDDEN_IMPS_FLAGS( FLAGS_FILTER( i ) ) ); */
-  CHECK_BOUND( l_val, "val" );
+  CHECK_BOUND( l_val, "val" )
   t_7 = GF_SIZE__FLAGS;
   t_9 = GF_WITH__HIDDEN__IMPS__FLAGS;
   t_11 = GF_FLAGS__FILTER;
   t_12 = OBJ_LVAR( 5 );
-  CHECK_BOUND( t_12, "i" );
+  CHECK_BOUND( t_12, "i" )
   t_10 = CALL_1ARGS( t_11, t_12 );
-  CHECK_FUNC_RESULT( t_10 );
+  CHECK_FUNC_RESULT( t_10 )
   t_8 = CALL_1ARGS( t_9, t_10 );
-  CHECK_FUNC_RESULT( t_8 );
+  CHECK_FUNC_RESULT( t_8 )
   t_6 = CALL_1ARGS( t_7, t_8 );
-  CHECK_FUNC_RESULT( t_6 );
-  C_DIFF_FIA( t_5, l_val, t_6 );
+  CHECK_FUNC_RESULT( t_6 )
+  C_DIFF_FIA( t_5, l_val, t_6 )
   l_val = t_5;
   
  }
@@ -3655,11 +3655,11 @@ static Obj  HdlrFunc17 (
   end ); */
  t_1 = GF_InstallOtherMethod;
  t_2 = OBJ_LVAR( 1 );
- CHECK_BOUND( t_2, "oper" );
- CHECK_BOUND( l_info, "info" );
- CHECK_BOUND( l_fampred, "fampred" );
+ CHECK_BOUND( t_2, "oper" )
+ CHECK_BOUND( l_info, "info" )
+ CHECK_BOUND( l_fampred, "fampred" )
  t_3 = OBJ_LVAR( 2 );
- CHECK_BOUND( t_3, "reqs" );
+ CHECK_BOUND( t_3, "reqs" )
  t_4 = NewFunction( NameFunc[18], NargFunc[18], NamsFunc[18], HdlrFunc18 );
  ENVI_FUNC( t_4 ) = TLS(CurrLVars);
  t_5 = NewBag( T_BODY, NUMBER_HEADER_ITEMS_BODY*sizeof(Obj) );
@@ -4053,8 +4053,8 @@ static Obj  HdlrFunc1 (
  
  /* LENGTH_SETTER_METHODS_2 := LENGTH_SETTER_METHODS_2 + 6; */
  t_2 = GC_LENGTH__SETTER__METHODS__2;
- CHECK_BOUND( t_2, "LENGTH_SETTER_METHODS_2" );
- C_SUM_FIA( t_1, t_2, INTOBJ_INT(6) );
+ CHECK_BOUND( t_2, "LENGTH_SETTER_METHODS_2" )
+ C_SUM_FIA( t_1, t_2, INTOBJ_INT(6) )
  AssGVar( G_LENGTH__SETTER__METHODS__2, t_1 );
  
  /* InstallAttributeFunction( function ( name, filter, getter, setter, tester, mutflag )
@@ -4290,17 +4290,17 @@ static Obj  HdlrFunc1 (
  /* InstallMethod( ViewObj, "default method using `PrintObj'", true, [ IS_OBJECT ], 0, PRINT_OBJ ); */
  t_1 = GF_InstallMethod;
  t_2 = GC_ViewObj;
- CHECK_BOUND( t_2, "ViewObj" );
+ CHECK_BOUND( t_2, "ViewObj" )
  C_NEW_STRING( t_3, 31, "default method using `PrintObj'" );
  t_4 = True;
  t_5 = NEW_PLIST( T_PLIST, 1 );
  SET_LEN_PLIST( t_5, 1 );
  t_6 = GC_IS__OBJECT;
- CHECK_BOUND( t_6, "IS_OBJECT" );
+ CHECK_BOUND( t_6, "IS_OBJECT" )
  SET_ELM_PLIST( t_5, 1, t_6 );
  CHANGED_BAG( t_5 );
  t_6 = GC_PRINT__OBJ;
- CHECK_BOUND( t_6, "PRINT_OBJ" );
+ CHECK_BOUND( t_6, "PRINT_OBJ" )
  CALL_6ARGS( t_1, t_2, t_3, t_4, t_5, INTOBJ_INT(0), t_6 );
  
  /* return; */

--- a/src/c_random.c
+++ b/src/c_random.c
@@ -52,57 +52,57 @@ static Obj  HdlrFunc2 (
  
  /* R_N := R_N mod 55 + 1; */
  t_3 = GC_R__N;
- CHECK_BOUND( t_3, "R_N" );
+ CHECK_BOUND( t_3, "R_N" )
  t_2 = MOD( t_3, INTOBJ_INT(55) );
- C_SUM_FIA( t_1, t_2, INTOBJ_INT(1) );
+ C_SUM_FIA( t_1, t_2, INTOBJ_INT(1) )
  AssGVar( G_R__N, t_1 );
  
  /* R_X[R_N] := (R_X[R_N] + R_X[((R_N + 30) mod 55 + 1)]) mod R_228; */
  t_1 = GC_R__X;
- CHECK_BOUND( t_1, "R_X" );
+ CHECK_BOUND( t_1, "R_X" )
  t_2 = GC_R__N;
- CHECK_BOUND( t_2, "R_N" );
- CHECK_INT_POS( t_2 );
+ CHECK_BOUND( t_2, "R_N" )
+ CHECK_INT_POS( t_2 )
  t_6 = GC_R__X;
- CHECK_BOUND( t_6, "R_X" );
+ CHECK_BOUND( t_6, "R_X" )
  t_7 = GC_R__N;
- CHECK_BOUND( t_7, "R_N" );
- CHECK_INT_POS( t_7 );
- C_ELM_LIST_FPL( t_5, t_6, t_7 );
+ CHECK_BOUND( t_7, "R_N" )
+ CHECK_INT_POS( t_7 )
+ C_ELM_LIST_FPL( t_5, t_6, t_7 )
  t_7 = GC_R__X;
- CHECK_BOUND( t_7, "R_X" );
+ CHECK_BOUND( t_7, "R_X" )
  t_11 = GC_R__N;
- CHECK_BOUND( t_11, "R_N" );
- C_SUM_FIA( t_10, t_11, INTOBJ_INT(30) );
+ CHECK_BOUND( t_11, "R_N" )
+ C_SUM_FIA( t_10, t_11, INTOBJ_INT(30) )
  t_9 = MOD( t_10, INTOBJ_INT(55) );
- C_SUM_FIA( t_8, t_9, INTOBJ_INT(1) );
- CHECK_INT_POS( t_8 );
- C_ELM_LIST_FPL( t_6, t_7, t_8 );
- C_SUM_FIA( t_4, t_5, t_6 );
+ C_SUM_FIA( t_8, t_9, INTOBJ_INT(1) )
+ CHECK_INT_POS( t_8 )
+ C_ELM_LIST_FPL( t_6, t_7, t_8 )
+ C_SUM_FIA( t_4, t_5, t_6 )
  t_5 = GC_R__228;
- CHECK_BOUND( t_5, "R_228" );
+ CHECK_BOUND( t_5, "R_228" )
  t_3 = MOD( t_4, t_5 );
- C_ASS_LIST_FPL( t_1, t_2, t_3 );
+ C_ASS_LIST_FPL( t_1, t_2, t_3 )
  
  /* return list[QUO_INT( R_X[R_N] * LEN_LIST( list ), R_228 ) + 1]; */
  t_4 = GF_QUO__INT;
  t_7 = GC_R__X;
- CHECK_BOUND( t_7, "R_X" );
+ CHECK_BOUND( t_7, "R_X" )
  t_8 = GC_R__N;
- CHECK_BOUND( t_8, "R_N" );
- CHECK_INT_POS( t_8 );
- C_ELM_LIST_FPL( t_6, t_7, t_8 );
+ CHECK_BOUND( t_8, "R_N" )
+ CHECK_INT_POS( t_8 )
+ C_ELM_LIST_FPL( t_6, t_7, t_8 )
  t_8 = GF_LEN__LIST;
  t_7 = CALL_1ARGS( t_8, a_list );
- CHECK_FUNC_RESULT( t_7 );
- C_PROD_FIA( t_5, t_6, t_7 );
+ CHECK_FUNC_RESULT( t_7 )
+ C_PROD_FIA( t_5, t_6, t_7 )
  t_6 = GC_R__228;
- CHECK_BOUND( t_6, "R_228" );
+ CHECK_BOUND( t_6, "R_228" )
  t_3 = CALL_2ARGS( t_4, t_5, t_6 );
- CHECK_FUNC_RESULT( t_3 );
- C_SUM_FIA( t_2, t_3, INTOBJ_INT(1) );
- CHECK_INT_POS( t_2 );
- C_ELM_LIST_FPL( t_1, a_list, t_2 );
+ CHECK_FUNC_RESULT( t_3 )
+ C_SUM_FIA( t_2, t_3, INTOBJ_INT(1) )
+ CHECK_INT_POS( t_2 )
+ C_ELM_LIST_FPL( t_1, a_list, t_2 )
  RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
@@ -146,7 +146,7 @@ static Obj  HdlrFunc3 (
  t_1 = NEW_PLIST( T_PLIST, 1 );
  SET_LEN_PLIST( t_1, 1 );
  t_3 = GC_R__228;
- CHECK_BOUND( t_3, "R_228" );
+ CHECK_BOUND( t_3, "R_228" )
  t_2 = MOD( a_n, t_3 );
  SET_ELM_PLIST( t_1, 1, t_2 );
  CHANGED_BAG( t_1 );
@@ -160,18 +160,18 @@ static Obj  HdlrFunc3 (
   
   /* R_X[i] := (1664525 * R_X[(i - 1)] + 1) mod R_228; */
   t_2 = GC_R__X;
-  CHECK_BOUND( t_2, "R_X" );
+  CHECK_BOUND( t_2, "R_X" )
   t_7 = GC_R__X;
-  CHECK_BOUND( t_7, "R_X" );
-  C_DIFF_INTOBJS( t_8, l_i, INTOBJ_INT(1) );
-  CHECK_INT_POS( t_8 );
-  C_ELM_LIST_FPL( t_6, t_7, t_8 );
-  C_PROD_FIA( t_5, INTOBJ_INT(1664525), t_6 );
-  C_SUM_FIA( t_4, t_5, INTOBJ_INT(1) );
+  CHECK_BOUND( t_7, "R_X" )
+  C_DIFF_INTOBJS( t_8, l_i, INTOBJ_INT(1) )
+  CHECK_INT_POS( t_8 )
+  C_ELM_LIST_FPL( t_6, t_7, t_8 )
+  C_PROD_FIA( t_5, INTOBJ_INT(1664525), t_6 )
+  C_SUM_FIA( t_4, t_5, INTOBJ_INT(1) )
   t_5 = GC_R__228;
-  CHECK_BOUND( t_5, "R_228" );
+  CHECK_BOUND( t_5, "R_228" )
   t_3 = MOD( t_4, t_5 );
-  C_ASS_LIST_FPL( t_2, l_i, t_3 );
+  C_ASS_LIST_FPL( t_2, l_i, t_3 )
   
  }
  /* od */
@@ -184,37 +184,37 @@ static Obj  HdlrFunc3 (
   
   /* R_N := R_N mod 55 + 1; */
   t_4 = GC_R__N;
-  CHECK_BOUND( t_4, "R_N" );
+  CHECK_BOUND( t_4, "R_N" )
   t_3 = MOD( t_4, INTOBJ_INT(55) );
-  C_SUM_FIA( t_2, t_3, INTOBJ_INT(1) );
+  C_SUM_FIA( t_2, t_3, INTOBJ_INT(1) )
   AssGVar( G_R__N, t_2 );
   
   /* R_X[R_N] := (R_X[R_N] + R_X[((R_N + 30) mod 55 + 1)]) mod R_228; */
   t_2 = GC_R__X;
-  CHECK_BOUND( t_2, "R_X" );
+  CHECK_BOUND( t_2, "R_X" )
   t_3 = GC_R__N;
-  CHECK_BOUND( t_3, "R_N" );
-  CHECK_INT_POS( t_3 );
+  CHECK_BOUND( t_3, "R_N" )
+  CHECK_INT_POS( t_3 )
   t_7 = GC_R__X;
-  CHECK_BOUND( t_7, "R_X" );
+  CHECK_BOUND( t_7, "R_X" )
   t_8 = GC_R__N;
-  CHECK_BOUND( t_8, "R_N" );
-  CHECK_INT_POS( t_8 );
-  C_ELM_LIST_FPL( t_6, t_7, t_8 );
+  CHECK_BOUND( t_8, "R_N" )
+  CHECK_INT_POS( t_8 )
+  C_ELM_LIST_FPL( t_6, t_7, t_8 )
   t_8 = GC_R__X;
-  CHECK_BOUND( t_8, "R_X" );
+  CHECK_BOUND( t_8, "R_X" )
   t_12 = GC_R__N;
-  CHECK_BOUND( t_12, "R_N" );
-  C_SUM_FIA( t_11, t_12, INTOBJ_INT(30) );
+  CHECK_BOUND( t_12, "R_N" )
+  C_SUM_FIA( t_11, t_12, INTOBJ_INT(30) )
   t_10 = MOD( t_11, INTOBJ_INT(55) );
-  C_SUM_FIA( t_9, t_10, INTOBJ_INT(1) );
-  CHECK_INT_POS( t_9 );
-  C_ELM_LIST_FPL( t_7, t_8, t_9 );
-  C_SUM_FIA( t_5, t_6, t_7 );
+  C_SUM_FIA( t_9, t_10, INTOBJ_INT(1) )
+  CHECK_INT_POS( t_9 )
+  C_ELM_LIST_FPL( t_7, t_8, t_9 )
+  C_SUM_FIA( t_5, t_6, t_7 )
   t_6 = GC_R__228;
-  CHECK_BOUND( t_6, "R_228" );
+  CHECK_BOUND( t_6, "R_228" )
   t_4 = MOD( t_5, t_6 );
-  C_ASS_LIST_FPL( t_2, t_3, t_4 );
+  C_ASS_LIST_FPL( t_2, t_3, t_4 )
   
  }
  /* od */
@@ -297,7 +297,7 @@ static Obj  HdlrFunc1 (
  
  /* if R_X = [  ] then */
  t_2 = GC_R__X;
- CHECK_BOUND( t_2, "R_X" );
+ CHECK_BOUND( t_2, "R_X" )
  t_3 = NEW_PLIST( T_PLIST, 0 );
  SET_LEN_PLIST( t_3, 0 );
  t_1 = (Obj)(UInt)(EQ( t_2, t_3 ));

--- a/src/c_type1.c
+++ b/src/c_type1.c
@@ -241,26 +241,26 @@ static Obj  HdlrFunc2 (
  t_4 = NEW_PLIST( T_PLIST, 1 );
  SET_LEN_PLIST( t_4, 1 );
  t_6 = GC_IsAttributeStoringRep;
- CHECK_BOUND( t_6, "IsAttributeStoringRep" );
+ CHECK_BOUND( t_6, "IsAttributeStoringRep" )
  if ( t_6 == False ) {
   t_5 = t_6;
  }
  else if ( t_6 == True ) {
-  CHECK_BOOL( a_tester );
+  CHECK_BOOL( a_tester )
   t_5 = a_tester;
  }
  else {
-  CHECK_FUNC( t_6 );
-  CHECK_FUNC( a_tester );
+  CHECK_FUNC( t_6 )
+  CHECK_FUNC( a_tester )
   t_5 = NewAndFilter( t_6, a_tester );
  }
  SET_ELM_PLIST( t_4, 1, t_5 );
  CHANGED_BAG( t_4 );
  t_5 = GC_GETTER__FLAGS;
- CHECK_BOUND( t_5, "GETTER_FLAGS" );
+ CHECK_BOUND( t_5, "GETTER_FLAGS" )
  t_7 = GF_GETTER__FUNCTION;
  t_6 = CALL_1ARGS( t_7, a_name );
- CHECK_FUNC_RESULT( t_6 );
+ CHECK_FUNC_RESULT( t_6 )
  CALL_6ARGS( t_1, a_getter, t_2, t_3, t_4, t_5, t_6 );
  
  /* return; */
@@ -292,7 +292,7 @@ static Obj  HdlrFunc4 (
  
  /* obj!.(name) := val; */
  t_1 = OBJ_LVAR_1UP( 1 );
- CHECK_BOUND( t_1, "name" );
+ CHECK_BOUND( t_1, "name" )
  if ( TNUM_OBJ(a_obj) == T_COMOBJ ) {
   AssPRec( a_obj, RNamObj(t_1), a_val );
 #ifdef HPCGAP
@@ -307,7 +307,7 @@ static Obj  HdlrFunc4 (
  /* SetFilterObj( obj, tester ); */
  t_1 = GF_SetFilterObj;
  t_2 = OBJ_LVAR_1UP( 2 );
- CHECK_BOUND( t_2, "tester" );
+ CHECK_BOUND( t_2, "tester" )
  CALL_2ARGS( t_1, a_obj, t_2 );
  
  /* return; */
@@ -350,7 +350,7 @@ static Obj  HdlrFunc3 (
  SET_BRK_CURR_STAT(0);
  
  /* if mutflag then */
- CHECK_BOOL( a_mutflag );
+ CHECK_BOOL( a_mutflag )
  t_1 = (Obj)(UInt)(a_mutflag != False);
  if ( t_1 ) {
   
@@ -365,11 +365,11 @@ static Obj  HdlrFunc3 (
   t_4 = NEW_PLIST( T_PLIST, 2 );
   SET_LEN_PLIST( t_4, 2 );
   t_5 = GC_IsAttributeStoringRep;
-  CHECK_BOUND( t_5, "IsAttributeStoringRep" );
+  CHECK_BOUND( t_5, "IsAttributeStoringRep" )
   SET_ELM_PLIST( t_4, 1, t_5 );
   CHANGED_BAG( t_4 );
   t_5 = GC_IS__OBJECT;
-  CHECK_BOUND( t_5, "IS_OBJECT" );
+  CHECK_BOUND( t_5, "IS_OBJECT" )
   SET_ELM_PLIST( t_4, 2, t_5 );
   CHANGED_BAG( t_4 );
   t_5 = NewFunction( NameFunc[4], NargFunc[4], NamsFunc[4], HdlrFunc4 );
@@ -394,20 +394,20 @@ static Obj  HdlrFunc3 (
   t_4 = NEW_PLIST( T_PLIST, 2 );
   SET_LEN_PLIST( t_4, 2 );
   t_5 = GC_IsAttributeStoringRep;
-  CHECK_BOUND( t_5, "IsAttributeStoringRep" );
+  CHECK_BOUND( t_5, "IsAttributeStoringRep" )
   SET_ELM_PLIST( t_4, 1, t_5 );
   CHANGED_BAG( t_4 );
   t_5 = GC_IS__OBJECT;
-  CHECK_BOUND( t_5, "IS_OBJECT" );
+  CHECK_BOUND( t_5, "IS_OBJECT" )
   SET_ELM_PLIST( t_4, 2, t_5 );
   CHANGED_BAG( t_4 );
   t_6 = GF_SETTER__FUNCTION;
   t_7 = OBJ_LVAR( 1 );
-  CHECK_BOUND( t_7, "name" );
+  CHECK_BOUND( t_7, "name" )
   t_8 = OBJ_LVAR( 2 );
-  CHECK_BOUND( t_8, "tester" );
+  CHECK_BOUND( t_8, "tester" )
   t_5 = CALL_2ARGS( t_6, t_7, t_8 );
-  CHECK_FUNC_RESULT( t_5 );
+  CHECK_FUNC_RESULT( t_5 )
   CALL_6ARGS( t_1, a_setter, t_2, t_3, t_4, INTOBJ_INT(0), t_5 );
   
  }
@@ -455,22 +455,22 @@ static Obj  HdlrFunc5 (
  t_2 = GF_WITH__IMPS__FLAGS;
  t_4 = GF_AND__FLAGS;
  t_3 = CALL_2ARGS( t_4, a_imp__filter, a_req__filter );
- CHECK_FUNC_RESULT( t_3 );
+ CHECK_FUNC_RESULT( t_3 )
  t_1 = CALL_1ARGS( t_2, t_3 );
- CHECK_FUNC_RESULT( t_1 );
+ CHECK_FUNC_RESULT( t_1 )
  a_imp__filter = t_1;
  
  /* type := Subtype( typeOfFamilies, IsAttributeStoringRep ); */
  t_2 = GF_Subtype;
  t_3 = GC_IsAttributeStoringRep;
- CHECK_BOUND( t_3, "IsAttributeStoringRep" );
+ CHECK_BOUND( t_3, "IsAttributeStoringRep" )
  t_1 = CALL_2ARGS( t_2, a_typeOfFamilies, t_3 );
- CHECK_FUNC_RESULT( t_1 );
+ CHECK_FUNC_RESULT( t_1 )
  l_type = t_1;
  
  /* for pair in CATEGORIES_FAMILY do */
  t_4 = GC_CATEGORIES__FAMILY;
- CHECK_BOUND( t_4, "CATEGORIES_FAMILY" );
+ CHECK_BOUND( t_4, "CATEGORIES_FAMILY" )
  if ( IS_SMALL_LIST(t_4) ) {
   t_3 = (Obj)(UInt)1;
   t_1 = INTOBJ_INT(1);
@@ -494,18 +494,18 @@ static Obj  HdlrFunc5 (
   
   /* if IS_SUBSET_FLAGS( imp_filter, pair[1] ) then */
   t_7 = GF_IS__SUBSET__FLAGS;
-  C_ELM_LIST_FPL( t_8, l_pair, INTOBJ_INT(1) );
+  C_ELM_LIST_FPL( t_8, l_pair, INTOBJ_INT(1) )
   t_6 = CALL_2ARGS( t_7, a_imp__filter, t_8 );
-  CHECK_FUNC_RESULT( t_6 );
-  CHECK_BOOL( t_6 );
+  CHECK_FUNC_RESULT( t_6 )
+  CHECK_BOOL( t_6 )
   t_5 = (Obj)(UInt)(t_6 != False);
   if ( t_5 ) {
    
    /* type := Subtype( type, pair[2] ); */
    t_6 = GF_Subtype;
-   C_ELM_LIST_FPL( t_7, l_pair, INTOBJ_INT(2) );
+   C_ELM_LIST_FPL( t_7, l_pair, INTOBJ_INT(2) )
    t_5 = CALL_2ARGS( t_6, l_type, t_7 );
-   CHECK_FUNC_RESULT( t_5 );
+   CHECK_FUNC_RESULT( t_5 )
    l_type = t_5;
    
   }
@@ -527,7 +527,7 @@ static Obj  HdlrFunc5 (
  /* family!.NAME := IMMUTABLE_COPY_OBJ( name ); */
  t_2 = GF_IMMUTABLE__COPY__OBJ;
  t_1 = CALL_1ARGS( t_2, a_name );
- CHECK_FUNC_RESULT( t_1 );
+ CHECK_FUNC_RESULT( t_1 )
  if ( TNUM_OBJ(l_family) == T_COMOBJ ) {
   AssPRec( l_family, R_NAME, t_1 );
 #ifdef HPCGAP
@@ -626,7 +626,7 @@ static Obj  HdlrFunc5 (
  else {
   t_1 = ELM_REC( l_family, R_TYPES__LIST__FAM );
  }
- C_ASS_LIST_FPL_INTOBJ( t_1, INTOBJ_INT(27), INTOBJ_INT(0) );
+ C_ASS_LIST_FPL_INTOBJ( t_1, INTOBJ_INT(27), INTOBJ_INT(0) )
  
  /* return family; */
  RES_BRK_CURR_STAT();
@@ -660,11 +660,11 @@ static Obj  HdlrFunc6 (
  /* return NEW_FAMILY( typeOfFamilies, name, EMPTY_FLAGS, EMPTY_FLAGS ); */
  t_2 = GF_NEW__FAMILY;
  t_3 = GC_EMPTY__FLAGS;
- CHECK_BOUND( t_3, "EMPTY_FLAGS" );
+ CHECK_BOUND( t_3, "EMPTY_FLAGS" )
  t_4 = GC_EMPTY__FLAGS;
- CHECK_BOUND( t_4, "EMPTY_FLAGS" );
+ CHECK_BOUND( t_4, "EMPTY_FLAGS" )
  t_1 = CALL_4ARGS( t_2, a_typeOfFamilies, a_name, t_3, t_4 );
- CHECK_FUNC_RESULT( t_1 );
+ CHECK_FUNC_RESULT( t_1 )
  RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
@@ -698,11 +698,11 @@ static Obj  HdlrFunc7 (
  t_2 = GF_NEW__FAMILY;
  t_4 = GF_FLAGS__FILTER;
  t_3 = CALL_1ARGS( t_4, a_req );
- CHECK_FUNC_RESULT( t_3 );
+ CHECK_FUNC_RESULT( t_3 )
  t_4 = GC_EMPTY__FLAGS;
- CHECK_BOUND( t_4, "EMPTY_FLAGS" );
+ CHECK_BOUND( t_4, "EMPTY_FLAGS" )
  t_1 = CALL_4ARGS( t_2, a_typeOfFamilies, a_name, t_3, t_4 );
- CHECK_FUNC_RESULT( t_1 );
+ CHECK_FUNC_RESULT( t_1 )
  RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
@@ -738,12 +738,12 @@ static Obj  HdlrFunc8 (
  t_2 = GF_NEW__FAMILY;
  t_4 = GF_FLAGS__FILTER;
  t_3 = CALL_1ARGS( t_4, a_req );
- CHECK_FUNC_RESULT( t_3 );
+ CHECK_FUNC_RESULT( t_3 )
  t_5 = GF_FLAGS__FILTER;
  t_4 = CALL_1ARGS( t_5, a_imp );
- CHECK_FUNC_RESULT( t_4 );
+ CHECK_FUNC_RESULT( t_4 )
  t_1 = CALL_4ARGS( t_2, a_typeOfFamilies, a_name, t_3, t_4 );
- CHECK_FUNC_RESULT( t_1 );
+ CHECK_FUNC_RESULT( t_1 )
  RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
@@ -781,15 +781,15 @@ static Obj  HdlrFunc9 (
  t_2 = GF_NEW__FAMILY;
  t_4 = GF_Subtype;
  t_3 = CALL_2ARGS( t_4, a_typeOfFamilies, a_filter );
- CHECK_FUNC_RESULT( t_3 );
+ CHECK_FUNC_RESULT( t_3 )
  t_5 = GF_FLAGS__FILTER;
  t_4 = CALL_1ARGS( t_5, a_req );
- CHECK_FUNC_RESULT( t_4 );
+ CHECK_FUNC_RESULT( t_4 )
  t_6 = GF_FLAGS__FILTER;
  t_5 = CALL_1ARGS( t_6, a_imp );
- CHECK_FUNC_RESULT( t_5 );
+ CHECK_FUNC_RESULT( t_5 )
  t_1 = CALL_4ARGS( t_2, t_3, a_name, t_4, t_5 );
- CHECK_FUNC_RESULT( t_1 );
+ CHECK_FUNC_RESULT( t_1 )
  RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
@@ -823,17 +823,17 @@ static Obj  HdlrFunc10 (
  /* if LEN_LIST( arg ) = 1 then */
  t_3 = GF_LEN__LIST;
  t_2 = CALL_1ARGS( t_3, a_arg );
- CHECK_FUNC_RESULT( t_2 );
+ CHECK_FUNC_RESULT( t_2 )
  t_1 = (Obj)(UInt)(EQ( t_2, INTOBJ_INT(1) ));
  if ( t_1 ) {
   
   /* return NewFamily2( TypeOfFamilies, arg[1] ); */
   t_2 = GF_NewFamily2;
   t_3 = GC_TypeOfFamilies;
-  CHECK_BOUND( t_3, "TypeOfFamilies" );
-  C_ELM_LIST_FPL( t_4, a_arg, INTOBJ_INT(1) );
+  CHECK_BOUND( t_3, "TypeOfFamilies" )
+  C_ELM_LIST_FPL( t_4, a_arg, INTOBJ_INT(1) )
   t_1 = CALL_2ARGS( t_2, t_3, t_4 );
-  CHECK_FUNC_RESULT( t_1 );
+  CHECK_FUNC_RESULT( t_1 )
   RES_BRK_CURR_STAT();
   SWITCH_TO_OLD_FRAME(oldFrame);
   return t_1;
@@ -844,18 +844,18 @@ static Obj  HdlrFunc10 (
  else {
   t_3 = GF_LEN__LIST;
   t_2 = CALL_1ARGS( t_3, a_arg );
-  CHECK_FUNC_RESULT( t_2 );
+  CHECK_FUNC_RESULT( t_2 )
   t_1 = (Obj)(UInt)(EQ( t_2, INTOBJ_INT(2) ));
   if ( t_1 ) {
    
    /* return NewFamily3( TypeOfFamilies, arg[1], arg[2] ); */
    t_2 = GF_NewFamily3;
    t_3 = GC_TypeOfFamilies;
-   CHECK_BOUND( t_3, "TypeOfFamilies" );
-   C_ELM_LIST_FPL( t_4, a_arg, INTOBJ_INT(1) );
-   C_ELM_LIST_FPL( t_5, a_arg, INTOBJ_INT(2) );
+   CHECK_BOUND( t_3, "TypeOfFamilies" )
+   C_ELM_LIST_FPL( t_4, a_arg, INTOBJ_INT(1) )
+   C_ELM_LIST_FPL( t_5, a_arg, INTOBJ_INT(2) )
    t_1 = CALL_3ARGS( t_2, t_3, t_4, t_5 );
-   CHECK_FUNC_RESULT( t_1 );
+   CHECK_FUNC_RESULT( t_1 )
    RES_BRK_CURR_STAT();
    SWITCH_TO_OLD_FRAME(oldFrame);
    return t_1;
@@ -866,19 +866,19 @@ static Obj  HdlrFunc10 (
   else {
    t_3 = GF_LEN__LIST;
    t_2 = CALL_1ARGS( t_3, a_arg );
-   CHECK_FUNC_RESULT( t_2 );
+   CHECK_FUNC_RESULT( t_2 )
    t_1 = (Obj)(UInt)(EQ( t_2, INTOBJ_INT(3) ));
    if ( t_1 ) {
     
     /* return NewFamily4( TypeOfFamilies, arg[1], arg[2], arg[3] ); */
     t_2 = GF_NewFamily4;
     t_3 = GC_TypeOfFamilies;
-    CHECK_BOUND( t_3, "TypeOfFamilies" );
-    C_ELM_LIST_FPL( t_4, a_arg, INTOBJ_INT(1) );
-    C_ELM_LIST_FPL( t_5, a_arg, INTOBJ_INT(2) );
-    C_ELM_LIST_FPL( t_6, a_arg, INTOBJ_INT(3) );
+    CHECK_BOUND( t_3, "TypeOfFamilies" )
+    C_ELM_LIST_FPL( t_4, a_arg, INTOBJ_INT(1) )
+    C_ELM_LIST_FPL( t_5, a_arg, INTOBJ_INT(2) )
+    C_ELM_LIST_FPL( t_6, a_arg, INTOBJ_INT(3) )
     t_1 = CALL_4ARGS( t_2, t_3, t_4, t_5, t_6 );
-    CHECK_FUNC_RESULT( t_1 );
+    CHECK_FUNC_RESULT( t_1 )
     RES_BRK_CURR_STAT();
     SWITCH_TO_OLD_FRAME(oldFrame);
     return t_1;
@@ -889,20 +889,20 @@ static Obj  HdlrFunc10 (
    else {
     t_3 = GF_LEN__LIST;
     t_2 = CALL_1ARGS( t_3, a_arg );
-    CHECK_FUNC_RESULT( t_2 );
+    CHECK_FUNC_RESULT( t_2 )
     t_1 = (Obj)(UInt)(EQ( t_2, INTOBJ_INT(4) ));
     if ( t_1 ) {
      
      /* return NewFamily5( TypeOfFamilies, arg[1], arg[2], arg[3], arg[4] ); */
      t_2 = GF_NewFamily5;
      t_3 = GC_TypeOfFamilies;
-     CHECK_BOUND( t_3, "TypeOfFamilies" );
-     C_ELM_LIST_FPL( t_4, a_arg, INTOBJ_INT(1) );
-     C_ELM_LIST_FPL( t_5, a_arg, INTOBJ_INT(2) );
-     C_ELM_LIST_FPL( t_6, a_arg, INTOBJ_INT(3) );
-     C_ELM_LIST_FPL( t_7, a_arg, INTOBJ_INT(4) );
+     CHECK_BOUND( t_3, "TypeOfFamilies" )
+     C_ELM_LIST_FPL( t_4, a_arg, INTOBJ_INT(1) )
+     C_ELM_LIST_FPL( t_5, a_arg, INTOBJ_INT(2) )
+     C_ELM_LIST_FPL( t_6, a_arg, INTOBJ_INT(3) )
+     C_ELM_LIST_FPL( t_7, a_arg, INTOBJ_INT(4) )
      t_1 = CALL_5ARGS( t_2, t_3, t_4, t_5, t_6, t_7 );
-     CHECK_FUNC_RESULT( t_1 );
+     CHECK_FUNC_RESULT( t_1 )
      RES_BRK_CURR_STAT();
      SWITCH_TO_OLD_FRAME(oldFrame);
      return t_1;
@@ -982,7 +982,7 @@ static Obj  HdlrFunc11 (
  /* hash := HASH_FLAGS( flags ) mod family!.HASH_SIZE + 1; */
  t_4 = GF_HASH__FLAGS;
  t_3 = CALL_1ARGS( t_4, a_flags );
- CHECK_FUNC_RESULT( t_3 );
+ CHECK_FUNC_RESULT( t_3 )
  if ( TNUM_OBJ(a_family) == T_COMOBJ ) {
   t_4 = ElmPRec( a_family, R_HASH__SIZE );
 #ifdef HPCGAP
@@ -994,47 +994,47 @@ static Obj  HdlrFunc11 (
   t_4 = ELM_REC( a_family, R_HASH__SIZE );
  }
  t_2 = MOD( t_3, t_4 );
- C_SUM_FIA( t_1, t_2, INTOBJ_INT(1) );
+ C_SUM_FIA( t_1, t_2, INTOBJ_INT(1) )
  l_hash = t_1;
  
  /* if IsBound( cache[hash] ) then */
- CHECK_INT_POS( l_hash );
+ CHECK_INT_POS( l_hash )
  t_2 = C_ISB_LIST( l_cache, l_hash );
  t_1 = (Obj)(UInt)(t_2 != False);
  if ( t_1 ) {
   
   /* cached := cache[hash]; */
-  C_ELM_LIST_FPL( t_1, l_cache, l_hash );
+  C_ELM_LIST_FPL( t_1, l_cache, l_hash )
   l_cached = t_1;
   
   /* if IS_EQUAL_FLAGS( flags, cached![2] ) then */
   t_3 = GF_IS__EQUAL__FLAGS;
   C_ELM_POSOBJ_NLE( t_4, l_cached, 2 );
   t_2 = CALL_2ARGS( t_3, a_flags, t_4 );
-  CHECK_FUNC_RESULT( t_2 );
-  CHECK_BOOL( t_2 );
+  CHECK_FUNC_RESULT( t_2 )
+  CHECK_BOOL( t_2 )
   t_1 = (Obj)(UInt)(t_2 != False);
   if ( t_1 ) {
    
    /* if IS_IDENTICAL_OBJ( data, cached![POS_DATA_TYPE] ) and IS_IDENTICAL_OBJ( typeOfTypes, TYPE_OBJ( cached ) ) then */
    t_4 = GF_IS__IDENTICAL__OBJ;
    t_6 = GC_POS__DATA__TYPE;
-   CHECK_BOUND( t_6, "POS_DATA_TYPE" );
-   CHECK_INT_SMALL_POS( t_6 );
+   CHECK_BOUND( t_6, "POS_DATA_TYPE" )
+   CHECK_INT_SMALL_POS( t_6 )
    C_ELM_POSOBJ_NLE( t_5, l_cached, INT_INTOBJ(t_6) );
    t_3 = CALL_2ARGS( t_4, a_data, t_5 );
-   CHECK_FUNC_RESULT( t_3 );
-   CHECK_BOOL( t_3 );
+   CHECK_FUNC_RESULT( t_3 )
+   CHECK_BOOL( t_3 )
    t_2 = (Obj)(UInt)(t_3 != False);
    t_1 = t_2;
    if ( t_1 ) {
     t_5 = GF_IS__IDENTICAL__OBJ;
     t_7 = GF_TYPE__OBJ;
     t_6 = CALL_1ARGS( t_7, l_cached );
-    CHECK_FUNC_RESULT( t_6 );
+    CHECK_FUNC_RESULT( t_6 )
     t_4 = CALL_2ARGS( t_5, a_typeOfTypes, t_6 );
-    CHECK_FUNC_RESULT( t_4 );
-    CHECK_BOOL( t_4 );
+    CHECK_FUNC_RESULT( t_4 )
+    CHECK_BOOL( t_4 )
     t_3 = (Obj)(UInt)(t_4 != False);
     t_1 = t_3;
    }
@@ -1042,8 +1042,8 @@ static Obj  HdlrFunc11 (
     
     /* NEW_TYPE_CACHE_HIT := NEW_TYPE_CACHE_HIT + 1; */
     t_2 = GC_NEW__TYPE__CACHE__HIT;
-    CHECK_BOUND( t_2, "NEW_TYPE_CACHE_HIT" );
-    C_SUM_FIA( t_1, t_2, INTOBJ_INT(1) );
+    CHECK_BOUND( t_2, "NEW_TYPE_CACHE_HIT" )
+    C_SUM_FIA( t_1, t_2, INTOBJ_INT(1) )
     AssGVar( G_NEW__TYPE__CACHE__HIT, t_1 );
     
     /* return cached; */
@@ -1068,8 +1068,8 @@ static Obj  HdlrFunc11 (
   
   /* NEW_TYPE_CACHE_MISS := NEW_TYPE_CACHE_MISS + 1; */
   t_2 = GC_NEW__TYPE__CACHE__MISS;
-  CHECK_BOUND( t_2, "NEW_TYPE_CACHE_MISS" );
-  C_SUM_FIA( t_1, t_2, INTOBJ_INT(1) );
+  CHECK_BOUND( t_2, "NEW_TYPE_CACHE_MISS" )
+  C_SUM_FIA( t_1, t_2, INTOBJ_INT(1) )
   AssGVar( G_NEW__TYPE__CACHE__MISS, t_1 );
   
  }
@@ -1077,15 +1077,15 @@ static Obj  HdlrFunc11 (
  
  /* NEW_TYPE_NEXT_ID := NEW_TYPE_NEXT_ID + 1; */
  t_2 = GC_NEW__TYPE__NEXT__ID;
- CHECK_BOUND( t_2, "NEW_TYPE_NEXT_ID" );
- C_SUM_FIA( t_1, t_2, INTOBJ_INT(1) );
+ CHECK_BOUND( t_2, "NEW_TYPE_NEXT_ID" )
+ C_SUM_FIA( t_1, t_2, INTOBJ_INT(1) )
  AssGVar( G_NEW__TYPE__NEXT__ID, t_1 );
  
  /* if NEW_TYPE_NEXT_ID >= NEW_TYPE_ID_LIMIT then */
  t_2 = GC_NEW__TYPE__NEXT__ID;
- CHECK_BOUND( t_2, "NEW_TYPE_NEXT_ID" );
+ CHECK_BOUND( t_2, "NEW_TYPE_NEXT_ID" )
  t_3 = GC_NEW__TYPE__ID__LIMIT;
- CHECK_BOUND( t_3, "NEW_TYPE_ID_LIMIT" );
+ CHECK_BOUND( t_3, "NEW_TYPE_ID_LIMIT" )
  t_1 = (Obj)(UInt)(! LT( t_2, t_3 ));
  if ( t_1 ) {
   
@@ -1101,7 +1101,7 @@ static Obj  HdlrFunc11 (
   /* NEW_TYPE_NEXT_ID := COMPACT_TYPE_IDS(  ); */
   t_2 = GF_COMPACT__TYPE__IDS;
   t_1 = CALL_0ARGS( t_2 );
-  CHECK_FUNC_RESULT( t_1 );
+  CHECK_FUNC_RESULT( t_1 )
   AssGVar( G_NEW__TYPE__NEXT__ID, t_1 );
   
  }
@@ -1118,17 +1118,17 @@ static Obj  HdlrFunc11 (
  
  /* type[POS_DATA_TYPE] := data; */
  t_1 = GC_POS__DATA__TYPE;
- CHECK_BOUND( t_1, "POS_DATA_TYPE" );
- CHECK_INT_POS( t_1 );
- C_ASS_LIST_FPL( l_type, t_1, a_data );
+ CHECK_BOUND( t_1, "POS_DATA_TYPE" )
+ CHECK_INT_POS( t_1 )
+ C_ASS_LIST_FPL( l_type, t_1, a_data )
  
  /* type[POS_NUMB_TYPE] := NEW_TYPE_NEXT_ID; */
  t_1 = GC_POS__NUMB__TYPE;
- CHECK_BOUND( t_1, "POS_NUMB_TYPE" );
- CHECK_INT_POS( t_1 );
+ CHECK_BOUND( t_1, "POS_NUMB_TYPE" )
+ CHECK_INT_POS( t_1 )
  t_2 = GC_NEW__TYPE__NEXT__ID;
- CHECK_BOUND( t_2, "NEW_TYPE_NEXT_ID" );
- C_ASS_LIST_FPL( l_type, t_1, t_2 );
+ CHECK_BOUND( t_2, "NEW_TYPE_NEXT_ID" )
+ C_ASS_LIST_FPL( l_type, t_1, t_2 )
  
  /* SET_TYPE_POSOBJ( type, typeOfTypes ); */
  t_1 = GF_SET__TYPE__POSOBJ;
@@ -1145,7 +1145,7 @@ static Obj  HdlrFunc11 (
  else {
   t_3 = ELM_REC( a_family, R_nTYPES );
  }
- C_PROD_FIA( t_2, INTOBJ_INT(3), t_3 );
+ C_PROD_FIA( t_2, INTOBJ_INT(3), t_3 )
  if ( TNUM_OBJ(a_family) == T_COMOBJ ) {
   t_3 = ElmPRec( a_family, R_HASH__SIZE );
 #ifdef HPCGAP
@@ -1175,8 +1175,8 @@ static Obj  HdlrFunc11 (
   else {
    t_3 = ELM_REC( a_family, R_HASH__SIZE );
   }
-  C_PROD_FIA( t_2, INTOBJ_INT(3), t_3 );
-  C_SUM_FIA( t_1, t_2, INTOBJ_INT(1) );
+  C_PROD_FIA( t_2, INTOBJ_INT(3), t_3 )
+  C_SUM_FIA( t_1, t_2, INTOBJ_INT(1) )
   l_ncl = t_1;
   
   /* for t in cache do */
@@ -1206,11 +1206,11 @@ static Obj  HdlrFunc11 (
    t_8 = GF_HASH__FLAGS;
    C_ELM_POSOBJ_NLE( t_9, l_t, 2 );
    t_7 = CALL_1ARGS( t_8, t_9 );
-   CHECK_FUNC_RESULT( t_7 );
+   CHECK_FUNC_RESULT( t_7 )
    t_6 = MOD( t_7, l_ncl );
-   C_SUM_FIA( t_5, t_6, INTOBJ_INT(1) );
-   CHECK_INT_POS( t_5 );
-   C_ASS_LIST_FPL( l_ncache, t_5, l_t );
+   C_SUM_FIA( t_5, t_6, INTOBJ_INT(1) )
+   CHECK_INT_POS( t_5 )
+   C_ASS_LIST_FPL( l_ncache, t_5, l_t )
    
   }
   /* od */
@@ -1242,11 +1242,11 @@ static Obj  HdlrFunc11 (
   /* ncache[HASH_FLAGS( flags ) mod ncl + 1] := type; */
   t_4 = GF_HASH__FLAGS;
   t_3 = CALL_1ARGS( t_4, a_flags );
-  CHECK_FUNC_RESULT( t_3 );
+  CHECK_FUNC_RESULT( t_3 )
   t_2 = MOD( t_3, l_ncl );
-  C_SUM_FIA( t_1, t_2, INTOBJ_INT(1) );
-  CHECK_INT_POS( t_1 );
-  C_ASS_LIST_FPL( l_ncache, t_1, l_type );
+  C_SUM_FIA( t_1, t_2, INTOBJ_INT(1) )
+  CHECK_INT_POS( t_1 )
+  C_ASS_LIST_FPL( l_ncache, t_1, l_type )
   
  }
  
@@ -1254,7 +1254,7 @@ static Obj  HdlrFunc11 (
  else {
   
   /* cache[hash] := type; */
-  C_ASS_LIST_FPL( l_cache, l_hash, l_type );
+  C_ASS_LIST_FPL( l_cache, l_hash, l_type )
   
  }
  /* fi */
@@ -1270,7 +1270,7 @@ static Obj  HdlrFunc11 (
  else {
   t_2 = ELM_REC( a_family, R_nTYPES );
  }
- C_SUM_FIA( t_1, t_2, INTOBJ_INT(1) );
+ C_SUM_FIA( t_1, t_2, INTOBJ_INT(1) )
  if ( TNUM_OBJ(a_family) == T_COMOBJ ) {
   AssPRec( a_family, R_nTYPES, t_1 );
 #ifdef HPCGAP
@@ -1333,14 +1333,14 @@ static Obj  HdlrFunc12 (
  }
  t_9 = GF_FLAGS__FILTER;
  t_8 = CALL_1ARGS( t_9, a_filter );
- CHECK_FUNC_RESULT( t_8 );
+ CHECK_FUNC_RESULT( t_8 )
  t_5 = CALL_2ARGS( t_6, t_7, t_8 );
- CHECK_FUNC_RESULT( t_5 );
+ CHECK_FUNC_RESULT( t_5 )
  t_3 = CALL_1ARGS( t_4, t_5 );
- CHECK_FUNC_RESULT( t_3 );
+ CHECK_FUNC_RESULT( t_3 )
  t_4 = False;
  t_1 = CALL_4ARGS( t_2, a_typeOfTypes, a_family, t_3, t_4 );
- CHECK_FUNC_RESULT( t_1 );
+ CHECK_FUNC_RESULT( t_1 )
  RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
@@ -1392,13 +1392,13 @@ static Obj  HdlrFunc13 (
  }
  t_9 = GF_FLAGS__FILTER;
  t_8 = CALL_1ARGS( t_9, a_filter );
- CHECK_FUNC_RESULT( t_8 );
+ CHECK_FUNC_RESULT( t_8 )
  t_5 = CALL_2ARGS( t_6, t_7, t_8 );
- CHECK_FUNC_RESULT( t_5 );
+ CHECK_FUNC_RESULT( t_5 )
  t_3 = CALL_1ARGS( t_4, t_5 );
- CHECK_FUNC_RESULT( t_3 );
+ CHECK_FUNC_RESULT( t_3 )
  t_1 = CALL_4ARGS( t_2, a_typeOfTypes, a_family, t_3, a_data );
- CHECK_FUNC_RESULT( t_1 );
+ CHECK_FUNC_RESULT( t_1 )
  RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
@@ -1431,10 +1431,10 @@ static Obj  HdlrFunc14 (
  
  /* if not IsFamily( arg[1] ) then */
  t_4 = GF_IsFamily;
- C_ELM_LIST_FPL( t_5, a_arg, INTOBJ_INT(1) );
+ C_ELM_LIST_FPL( t_5, a_arg, INTOBJ_INT(1) )
  t_3 = CALL_1ARGS( t_4, t_5 );
- CHECK_FUNC_RESULT( t_3 );
- CHECK_BOOL( t_3 );
+ CHECK_FUNC_RESULT( t_3 )
+ CHECK_BOOL( t_3 )
  t_2 = (Obj)(UInt)(t_3 != False);
  t_1 = (Obj)(UInt)( ! ((Int)t_2) );
  if ( t_1 ) {
@@ -1450,18 +1450,18 @@ static Obj  HdlrFunc14 (
  /* if LEN_LIST( arg ) = 2 then */
  t_3 = GF_LEN__LIST;
  t_2 = CALL_1ARGS( t_3, a_arg );
- CHECK_FUNC_RESULT( t_2 );
+ CHECK_FUNC_RESULT( t_2 )
  t_1 = (Obj)(UInt)(EQ( t_2, INTOBJ_INT(2) ));
  if ( t_1 ) {
   
   /* type := NewType3( TypeOfTypes, arg[1], arg[2] ); */
   t_2 = GF_NewType3;
   t_3 = GC_TypeOfTypes;
-  CHECK_BOUND( t_3, "TypeOfTypes" );
-  C_ELM_LIST_FPL( t_4, a_arg, INTOBJ_INT(1) );
-  C_ELM_LIST_FPL( t_5, a_arg, INTOBJ_INT(2) );
+  CHECK_BOUND( t_3, "TypeOfTypes" )
+  C_ELM_LIST_FPL( t_4, a_arg, INTOBJ_INT(1) )
+  C_ELM_LIST_FPL( t_5, a_arg, INTOBJ_INT(2) )
   t_1 = CALL_3ARGS( t_2, t_3, t_4, t_5 );
-  CHECK_FUNC_RESULT( t_1 );
+  CHECK_FUNC_RESULT( t_1 )
   l_type = t_1;
   
  }
@@ -1470,19 +1470,19 @@ static Obj  HdlrFunc14 (
  else {
   t_3 = GF_LEN__LIST;
   t_2 = CALL_1ARGS( t_3, a_arg );
-  CHECK_FUNC_RESULT( t_2 );
+  CHECK_FUNC_RESULT( t_2 )
   t_1 = (Obj)(UInt)(EQ( t_2, INTOBJ_INT(3) ));
   if ( t_1 ) {
    
    /* type := NewType4( TypeOfTypes, arg[1], arg[2], arg[3] ); */
    t_2 = GF_NewType4;
    t_3 = GC_TypeOfTypes;
-   CHECK_BOUND( t_3, "TypeOfTypes" );
-   C_ELM_LIST_FPL( t_4, a_arg, INTOBJ_INT(1) );
-   C_ELM_LIST_FPL( t_5, a_arg, INTOBJ_INT(2) );
-   C_ELM_LIST_FPL( t_6, a_arg, INTOBJ_INT(3) );
+   CHECK_BOUND( t_3, "TypeOfTypes" )
+   C_ELM_LIST_FPL( t_4, a_arg, INTOBJ_INT(1) )
+   C_ELM_LIST_FPL( t_5, a_arg, INTOBJ_INT(2) )
+   C_ELM_LIST_FPL( t_6, a_arg, INTOBJ_INT(3) )
    t_1 = CALL_4ARGS( t_2, t_3, t_4, t_5, t_6 );
-   CHECK_FUNC_RESULT( t_1 );
+   CHECK_FUNC_RESULT( t_1 )
    l_type = t_1;
    
   }
@@ -1500,7 +1500,7 @@ static Obj  HdlrFunc14 (
  /* fi */
  
  /* return type; */
- CHECK_BOUND( l_type, "type" );
+ CHECK_BOUND( l_type, "type" )
  RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return l_type;
@@ -1541,41 +1541,41 @@ static Obj  HdlrFunc15 (
  /* new := NEW_TYPE( TypeOfTypes, type![1], WITH_IMPS_FLAGS( AND_FLAGS( type![2], FLAGS_FILTER( filter ) ) ), type![POS_DATA_TYPE] ); */
  t_2 = GF_NEW__TYPE;
  t_3 = GC_TypeOfTypes;
- CHECK_BOUND( t_3, "TypeOfTypes" );
+ CHECK_BOUND( t_3, "TypeOfTypes" )
  C_ELM_POSOBJ_NLE( t_4, a_type, 1 );
  t_6 = GF_WITH__IMPS__FLAGS;
  t_8 = GF_AND__FLAGS;
  C_ELM_POSOBJ_NLE( t_9, a_type, 2 );
  t_11 = GF_FLAGS__FILTER;
  t_10 = CALL_1ARGS( t_11, a_filter );
- CHECK_FUNC_RESULT( t_10 );
+ CHECK_FUNC_RESULT( t_10 )
  t_7 = CALL_2ARGS( t_8, t_9, t_10 );
- CHECK_FUNC_RESULT( t_7 );
+ CHECK_FUNC_RESULT( t_7 )
  t_5 = CALL_1ARGS( t_6, t_7 );
- CHECK_FUNC_RESULT( t_5 );
+ CHECK_FUNC_RESULT( t_5 )
  t_7 = GC_POS__DATA__TYPE;
- CHECK_BOUND( t_7, "POS_DATA_TYPE" );
- CHECK_INT_SMALL_POS( t_7 );
+ CHECK_BOUND( t_7, "POS_DATA_TYPE" )
+ CHECK_INT_SMALL_POS( t_7 )
  C_ELM_POSOBJ_NLE( t_6, a_type, INT_INTOBJ(t_7) );
  t_1 = CALL_4ARGS( t_2, t_3, t_4, t_5, t_6 );
- CHECK_FUNC_RESULT( t_1 );
+ CHECK_FUNC_RESULT( t_1 )
  l_new = t_1;
  
  /* for i in [ POS_FIRST_FREE_TYPE .. LEN_POSOBJ( type ) ] do */
  t_2 = GC_POS__FIRST__FREE__TYPE;
- CHECK_BOUND( t_2, "POS_FIRST_FREE_TYPE" );
- CHECK_INT_SMALL( t_2 );
+ CHECK_BOUND( t_2, "POS_FIRST_FREE_TYPE" )
+ CHECK_INT_SMALL( t_2 )
  t_4 = GF_LEN__POSOBJ;
  t_3 = CALL_1ARGS( t_4, a_type );
- CHECK_FUNC_RESULT( t_3 );
- CHECK_INT_SMALL( t_3 );
+ CHECK_FUNC_RESULT( t_3 )
+ CHECK_INT_SMALL( t_3 )
  for ( t_1 = t_2;
        ((Int)t_1) <= ((Int)t_3);
        t_1 = (Obj)(((UInt)t_1)+4) ) {
   l_i = t_1;
   
   /* if IsBound( type![i]) then */
-  CHECK_INT_SMALL_POS( l_i );
+  CHECK_INT_SMALL_POS( l_i )
   if ( TNUM_OBJ(a_type) == T_POSOBJ ) {
    t_5 = (INT_INTOBJ(l_i) <= SIZE_OBJ(a_type)/sizeof(Obj)-1
       && ELM_PLIST(a_type,INT_INTOBJ(l_i)) != 0 ? True : False);
@@ -1592,7 +1592,7 @@ static Obj  HdlrFunc15 (
    
    /* new![i] := type![i]; */
    C_ELM_POSOBJ_NLE( t_4, a_type, INT_INTOBJ(l_i) );
-   C_ASS_POSOBJ( l_new, INT_INTOBJ(l_i), t_4 );
+   C_ASS_POSOBJ( l_new, INT_INTOBJ(l_i), t_4 )
    
   }
   /* fi */
@@ -1642,37 +1642,37 @@ static Obj  HdlrFunc16 (
  /* new := NEW_TYPE( TypeOfTypes, type![1], WITH_IMPS_FLAGS( AND_FLAGS( type![2], FLAGS_FILTER( filter ) ) ), data ); */
  t_2 = GF_NEW__TYPE;
  t_3 = GC_TypeOfTypes;
- CHECK_BOUND( t_3, "TypeOfTypes" );
+ CHECK_BOUND( t_3, "TypeOfTypes" )
  C_ELM_POSOBJ_NLE( t_4, a_type, 1 );
  t_6 = GF_WITH__IMPS__FLAGS;
  t_8 = GF_AND__FLAGS;
  C_ELM_POSOBJ_NLE( t_9, a_type, 2 );
  t_11 = GF_FLAGS__FILTER;
  t_10 = CALL_1ARGS( t_11, a_filter );
- CHECK_FUNC_RESULT( t_10 );
+ CHECK_FUNC_RESULT( t_10 )
  t_7 = CALL_2ARGS( t_8, t_9, t_10 );
- CHECK_FUNC_RESULT( t_7 );
+ CHECK_FUNC_RESULT( t_7 )
  t_5 = CALL_1ARGS( t_6, t_7 );
- CHECK_FUNC_RESULT( t_5 );
+ CHECK_FUNC_RESULT( t_5 )
  t_1 = CALL_4ARGS( t_2, t_3, t_4, t_5, a_data );
- CHECK_FUNC_RESULT( t_1 );
+ CHECK_FUNC_RESULT( t_1 )
  l_new = t_1;
  
  /* for i in [ POS_FIRST_FREE_TYPE .. LEN_POSOBJ( type ) ] do */
  t_2 = GC_POS__FIRST__FREE__TYPE;
- CHECK_BOUND( t_2, "POS_FIRST_FREE_TYPE" );
- CHECK_INT_SMALL( t_2 );
+ CHECK_BOUND( t_2, "POS_FIRST_FREE_TYPE" )
+ CHECK_INT_SMALL( t_2 )
  t_4 = GF_LEN__POSOBJ;
  t_3 = CALL_1ARGS( t_4, a_type );
- CHECK_FUNC_RESULT( t_3 );
- CHECK_INT_SMALL( t_3 );
+ CHECK_FUNC_RESULT( t_3 )
+ CHECK_INT_SMALL( t_3 )
  for ( t_1 = t_2;
        ((Int)t_1) <= ((Int)t_3);
        t_1 = (Obj)(((UInt)t_1)+4) ) {
   l_i = t_1;
   
   /* if IsBound( type![i]) then */
-  CHECK_INT_SMALL_POS( l_i );
+  CHECK_INT_SMALL_POS( l_i )
   if ( TNUM_OBJ(a_type) == T_POSOBJ ) {
    t_5 = (INT_INTOBJ(l_i) <= SIZE_OBJ(a_type)/sizeof(Obj)-1
       && ELM_PLIST(a_type,INT_INTOBJ(l_i)) != 0 ? True : False);
@@ -1689,7 +1689,7 @@ static Obj  HdlrFunc16 (
    
    /* new![i] := type![i]; */
    C_ELM_POSOBJ_NLE( t_4, a_type, INT_INTOBJ(l_i) );
-   C_ASS_POSOBJ( l_new, INT_INTOBJ(l_i), t_4 );
+   C_ASS_POSOBJ( l_new, INT_INTOBJ(l_i), t_4 )
    
   }
   /* fi */
@@ -1728,10 +1728,10 @@ static Obj  HdlrFunc17 (
  
  /* if not IsType( arg[1] ) then */
  t_4 = GF_IsType;
- C_ELM_LIST_FPL( t_5, a_arg, INTOBJ_INT(1) );
+ C_ELM_LIST_FPL( t_5, a_arg, INTOBJ_INT(1) )
  t_3 = CALL_1ARGS( t_4, t_5 );
- CHECK_FUNC_RESULT( t_3 );
- CHECK_BOOL( t_3 );
+ CHECK_FUNC_RESULT( t_3 )
+ CHECK_BOOL( t_3 )
  t_2 = (Obj)(UInt)(t_3 != False);
  t_1 = (Obj)(UInt)( ! ((Int)t_2) );
  if ( t_1 ) {
@@ -1747,16 +1747,16 @@ static Obj  HdlrFunc17 (
  /* if LEN_LIST( arg ) = 2 then */
  t_3 = GF_LEN__LIST;
  t_2 = CALL_1ARGS( t_3, a_arg );
- CHECK_FUNC_RESULT( t_2 );
+ CHECK_FUNC_RESULT( t_2 )
  t_1 = (Obj)(UInt)(EQ( t_2, INTOBJ_INT(2) ));
  if ( t_1 ) {
   
   /* return Subtype2( arg[1], arg[2] ); */
   t_2 = GF_Subtype2;
-  C_ELM_LIST_FPL( t_3, a_arg, INTOBJ_INT(1) );
-  C_ELM_LIST_FPL( t_4, a_arg, INTOBJ_INT(2) );
+  C_ELM_LIST_FPL( t_3, a_arg, INTOBJ_INT(1) )
+  C_ELM_LIST_FPL( t_4, a_arg, INTOBJ_INT(2) )
   t_1 = CALL_2ARGS( t_2, t_3, t_4 );
-  CHECK_FUNC_RESULT( t_1 );
+  CHECK_FUNC_RESULT( t_1 )
   RES_BRK_CURR_STAT();
   SWITCH_TO_OLD_FRAME(oldFrame);
   return t_1;
@@ -1768,11 +1768,11 @@ static Obj  HdlrFunc17 (
   
   /* return Subtype3( arg[1], arg[2], arg[3] ); */
   t_2 = GF_Subtype3;
-  C_ELM_LIST_FPL( t_3, a_arg, INTOBJ_INT(1) );
-  C_ELM_LIST_FPL( t_4, a_arg, INTOBJ_INT(2) );
-  C_ELM_LIST_FPL( t_5, a_arg, INTOBJ_INT(3) );
+  C_ELM_LIST_FPL( t_3, a_arg, INTOBJ_INT(1) )
+  C_ELM_LIST_FPL( t_4, a_arg, INTOBJ_INT(2) )
+  C_ELM_LIST_FPL( t_5, a_arg, INTOBJ_INT(3) )
   t_1 = CALL_3ARGS( t_2, t_3, t_4, t_5 );
-  CHECK_FUNC_RESULT( t_1 );
+  CHECK_FUNC_RESULT( t_1 )
   RES_BRK_CURR_STAT();
   SWITCH_TO_OLD_FRAME(oldFrame);
   return t_1;
@@ -1819,38 +1819,38 @@ static Obj  HdlrFunc18 (
  /* new := NEW_TYPE( TypeOfTypes, type![1], SUB_FLAGS( type![2], FLAGS_FILTER( filter ) ), type![POS_DATA_TYPE] ); */
  t_2 = GF_NEW__TYPE;
  t_3 = GC_TypeOfTypes;
- CHECK_BOUND( t_3, "TypeOfTypes" );
+ CHECK_BOUND( t_3, "TypeOfTypes" )
  C_ELM_POSOBJ_NLE( t_4, a_type, 1 );
  t_6 = GF_SUB__FLAGS;
  C_ELM_POSOBJ_NLE( t_7, a_type, 2 );
  t_9 = GF_FLAGS__FILTER;
  t_8 = CALL_1ARGS( t_9, a_filter );
- CHECK_FUNC_RESULT( t_8 );
+ CHECK_FUNC_RESULT( t_8 )
  t_5 = CALL_2ARGS( t_6, t_7, t_8 );
- CHECK_FUNC_RESULT( t_5 );
+ CHECK_FUNC_RESULT( t_5 )
  t_7 = GC_POS__DATA__TYPE;
- CHECK_BOUND( t_7, "POS_DATA_TYPE" );
- CHECK_INT_SMALL_POS( t_7 );
+ CHECK_BOUND( t_7, "POS_DATA_TYPE" )
+ CHECK_INT_SMALL_POS( t_7 )
  C_ELM_POSOBJ_NLE( t_6, a_type, INT_INTOBJ(t_7) );
  t_1 = CALL_4ARGS( t_2, t_3, t_4, t_5, t_6 );
- CHECK_FUNC_RESULT( t_1 );
+ CHECK_FUNC_RESULT( t_1 )
  l_new = t_1;
  
  /* for i in [ POS_FIRST_FREE_TYPE .. LEN_POSOBJ( type ) ] do */
  t_2 = GC_POS__FIRST__FREE__TYPE;
- CHECK_BOUND( t_2, "POS_FIRST_FREE_TYPE" );
- CHECK_INT_SMALL( t_2 );
+ CHECK_BOUND( t_2, "POS_FIRST_FREE_TYPE" )
+ CHECK_INT_SMALL( t_2 )
  t_4 = GF_LEN__POSOBJ;
  t_3 = CALL_1ARGS( t_4, a_type );
- CHECK_FUNC_RESULT( t_3 );
- CHECK_INT_SMALL( t_3 );
+ CHECK_FUNC_RESULT( t_3 )
+ CHECK_INT_SMALL( t_3 )
  for ( t_1 = t_2;
        ((Int)t_1) <= ((Int)t_3);
        t_1 = (Obj)(((UInt)t_1)+4) ) {
   l_i = t_1;
   
   /* if IsBound( type![i]) then */
-  CHECK_INT_SMALL_POS( l_i );
+  CHECK_INT_SMALL_POS( l_i )
   if ( TNUM_OBJ(a_type) == T_POSOBJ ) {
    t_5 = (INT_INTOBJ(l_i) <= SIZE_OBJ(a_type)/sizeof(Obj)-1
       && ELM_PLIST(a_type,INT_INTOBJ(l_i)) != 0 ? True : False);
@@ -1867,7 +1867,7 @@ static Obj  HdlrFunc18 (
    
    /* new![i] := type![i]; */
    C_ELM_POSOBJ_NLE( t_4, a_type, INT_INTOBJ(l_i) );
-   C_ASS_POSOBJ( l_new, INT_INTOBJ(l_i), t_4 );
+   C_ASS_POSOBJ( l_new, INT_INTOBJ(l_i), t_4 )
    
   }
   /* fi */
@@ -1915,34 +1915,34 @@ static Obj  HdlrFunc19 (
  /* new := NEW_TYPE( TypeOfTypes, type![1], SUB_FLAGS( type![2], FLAGS_FILTER( filter ) ), data ); */
  t_2 = GF_NEW__TYPE;
  t_3 = GC_TypeOfTypes;
- CHECK_BOUND( t_3, "TypeOfTypes" );
+ CHECK_BOUND( t_3, "TypeOfTypes" )
  C_ELM_POSOBJ_NLE( t_4, a_type, 1 );
  t_6 = GF_SUB__FLAGS;
  C_ELM_POSOBJ_NLE( t_7, a_type, 2 );
  t_9 = GF_FLAGS__FILTER;
  t_8 = CALL_1ARGS( t_9, a_filter );
- CHECK_FUNC_RESULT( t_8 );
+ CHECK_FUNC_RESULT( t_8 )
  t_5 = CALL_2ARGS( t_6, t_7, t_8 );
- CHECK_FUNC_RESULT( t_5 );
+ CHECK_FUNC_RESULT( t_5 )
  t_1 = CALL_4ARGS( t_2, t_3, t_4, t_5, a_data );
- CHECK_FUNC_RESULT( t_1 );
+ CHECK_FUNC_RESULT( t_1 )
  l_new = t_1;
  
  /* for i in [ POS_FIRST_FREE_TYPE .. LEN_POSOBJ( type ) ] do */
  t_2 = GC_POS__FIRST__FREE__TYPE;
- CHECK_BOUND( t_2, "POS_FIRST_FREE_TYPE" );
- CHECK_INT_SMALL( t_2 );
+ CHECK_BOUND( t_2, "POS_FIRST_FREE_TYPE" )
+ CHECK_INT_SMALL( t_2 )
  t_4 = GF_LEN__POSOBJ;
  t_3 = CALL_1ARGS( t_4, a_type );
- CHECK_FUNC_RESULT( t_3 );
- CHECK_INT_SMALL( t_3 );
+ CHECK_FUNC_RESULT( t_3 )
+ CHECK_INT_SMALL( t_3 )
  for ( t_1 = t_2;
        ((Int)t_1) <= ((Int)t_3);
        t_1 = (Obj)(((UInt)t_1)+4) ) {
   l_i = t_1;
   
   /* if IsBound( type![i]) then */
-  CHECK_INT_SMALL_POS( l_i );
+  CHECK_INT_SMALL_POS( l_i )
   if ( TNUM_OBJ(a_type) == T_POSOBJ ) {
    t_5 = (INT_INTOBJ(l_i) <= SIZE_OBJ(a_type)/sizeof(Obj)-1
       && ELM_PLIST(a_type,INT_INTOBJ(l_i)) != 0 ? True : False);
@@ -1959,7 +1959,7 @@ static Obj  HdlrFunc19 (
    
    /* new![i] := type![i]; */
    C_ELM_POSOBJ_NLE( t_4, a_type, INT_INTOBJ(l_i) );
-   C_ASS_POSOBJ( l_new, INT_INTOBJ(l_i), t_4 );
+   C_ASS_POSOBJ( l_new, INT_INTOBJ(l_i), t_4 )
    
   }
   /* fi */
@@ -1998,10 +1998,10 @@ static Obj  HdlrFunc20 (
  
  /* if not IsType( arg[1] ) then */
  t_4 = GF_IsType;
- C_ELM_LIST_FPL( t_5, a_arg, INTOBJ_INT(1) );
+ C_ELM_LIST_FPL( t_5, a_arg, INTOBJ_INT(1) )
  t_3 = CALL_1ARGS( t_4, t_5 );
- CHECK_FUNC_RESULT( t_3 );
- CHECK_BOOL( t_3 );
+ CHECK_FUNC_RESULT( t_3 )
+ CHECK_BOOL( t_3 )
  t_2 = (Obj)(UInt)(t_3 != False);
  t_1 = (Obj)(UInt)( ! ((Int)t_2) );
  if ( t_1 ) {
@@ -2017,16 +2017,16 @@ static Obj  HdlrFunc20 (
  /* if LEN_LIST( arg ) = 2 then */
  t_3 = GF_LEN__LIST;
  t_2 = CALL_1ARGS( t_3, a_arg );
- CHECK_FUNC_RESULT( t_2 );
+ CHECK_FUNC_RESULT( t_2 )
  t_1 = (Obj)(UInt)(EQ( t_2, INTOBJ_INT(2) ));
  if ( t_1 ) {
   
   /* return SupType2( arg[1], arg[2] ); */
   t_2 = GF_SupType2;
-  C_ELM_LIST_FPL( t_3, a_arg, INTOBJ_INT(1) );
-  C_ELM_LIST_FPL( t_4, a_arg, INTOBJ_INT(2) );
+  C_ELM_LIST_FPL( t_3, a_arg, INTOBJ_INT(1) )
+  C_ELM_LIST_FPL( t_4, a_arg, INTOBJ_INT(2) )
   t_1 = CALL_2ARGS( t_2, t_3, t_4 );
-  CHECK_FUNC_RESULT( t_1 );
+  CHECK_FUNC_RESULT( t_1 )
   RES_BRK_CURR_STAT();
   SWITCH_TO_OLD_FRAME(oldFrame);
   return t_1;
@@ -2038,11 +2038,11 @@ static Obj  HdlrFunc20 (
   
   /* return SupType3( arg[1], arg[2], arg[3] ); */
   t_2 = GF_SupType3;
-  C_ELM_LIST_FPL( t_3, a_arg, INTOBJ_INT(1) );
-  C_ELM_LIST_FPL( t_4, a_arg, INTOBJ_INT(2) );
-  C_ELM_LIST_FPL( t_5, a_arg, INTOBJ_INT(3) );
+  C_ELM_LIST_FPL( t_3, a_arg, INTOBJ_INT(1) )
+  C_ELM_LIST_FPL( t_4, a_arg, INTOBJ_INT(2) )
+  C_ELM_LIST_FPL( t_5, a_arg, INTOBJ_INT(3) )
   t_1 = CALL_3ARGS( t_2, t_3, t_4, t_5 );
-  CHECK_FUNC_RESULT( t_1 );
+  CHECK_FUNC_RESULT( t_1 )
   RES_BRK_CURR_STAT();
   SWITCH_TO_OLD_FRAME(oldFrame);
   return t_1;
@@ -2130,8 +2130,8 @@ static Obj  HdlrFunc23 (
  
  /* return K![POS_DATA_TYPE]; */
  t_2 = GC_POS__DATA__TYPE;
- CHECK_BOUND( t_2, "POS_DATA_TYPE" );
- CHECK_INT_SMALL_POS( t_2 );
+ CHECK_BOUND( t_2, "POS_DATA_TYPE" )
+ CHECK_INT_SMALL_POS( t_2 )
  C_ELM_POSOBJ_NLE( t_1, a_K, INT_INTOBJ(t_2) );
  RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
@@ -2160,9 +2160,9 @@ static Obj  HdlrFunc24 (
  
  /* K![POS_DATA_TYPE] := data; */
  t_1 = GC_POS__DATA__TYPE;
- CHECK_BOUND( t_1, "POS_DATA_TYPE" );
- CHECK_INT_SMALL_POS( t_1 );
- C_ASS_POSOBJ( a_K, INT_INTOBJ(t_1), a_data );
+ CHECK_BOUND( t_1, "POS_DATA_TYPE" )
+ CHECK_INT_SMALL_POS( t_1 )
+ C_ASS_POSOBJ( a_K, INT_INTOBJ(t_1), a_data )
  
  /* return; */
  RES_BRK_CURR_STAT();
@@ -2196,9 +2196,9 @@ static Obj  HdlrFunc25 (
  t_2 = GF_FlagsType;
  t_4 = GF_TypeObj;
  t_3 = CALL_1ARGS( t_4, a_obj );
- CHECK_FUNC_RESULT( t_3 );
+ CHECK_FUNC_RESULT( t_3 )
  t_1 = CALL_1ARGS( t_2, t_3 );
- CHECK_FUNC_RESULT( t_1 );
+ CHECK_FUNC_RESULT( t_1 )
  RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
@@ -2230,9 +2230,9 @@ static Obj  HdlrFunc26 (
  t_2 = GF_DataType;
  t_4 = GF_TypeObj;
  t_3 = CALL_1ARGS( t_4, a_obj );
- CHECK_FUNC_RESULT( t_3 );
+ CHECK_FUNC_RESULT( t_3 )
  t_1 = CALL_1ARGS( t_2, t_3 );
- CHECK_FUNC_RESULT( t_1 );
+ CHECK_FUNC_RESULT( t_1 )
  RES_BRK_CURR_STAT();
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
@@ -2264,8 +2264,8 @@ static Obj  HdlrFunc27 (
  /* if not IsType( type ) then */
  t_4 = GF_IsType;
  t_3 = CALL_1ARGS( t_4, a_type );
- CHECK_FUNC_RESULT( t_3 );
- CHECK_BOOL( t_3 );
+ CHECK_FUNC_RESULT( t_3 )
+ CHECK_BOOL( t_3 )
  t_2 = (Obj)(UInt)(t_3 != False);
  t_1 = (Obj)(UInt)( ! ((Int)t_2) );
  if ( t_1 ) {
@@ -2281,8 +2281,8 @@ static Obj  HdlrFunc27 (
  /* if IS_LIST( obj ) then */
  t_3 = GF_IS__LIST;
  t_2 = CALL_1ARGS( t_3, a_obj );
- CHECK_FUNC_RESULT( t_2 );
- CHECK_BOOL( t_2 );
+ CHECK_FUNC_RESULT( t_2 )
+ CHECK_BOOL( t_2 )
  t_1 = (Obj)(UInt)(t_2 != False);
  if ( t_1 ) {
   
@@ -2296,8 +2296,8 @@ static Obj  HdlrFunc27 (
  else {
   t_3 = GF_IS__REC;
   t_2 = CALL_1ARGS( t_3, a_obj );
-  CHECK_FUNC_RESULT( t_2 );
-  CHECK_BOOL( t_2 );
+  CHECK_FUNC_RESULT( t_2 )
+  CHECK_BOOL( t_2 )
   t_1 = (Obj)(UInt)(t_2 != False);
   if ( t_1 ) {
    
@@ -2312,8 +2312,8 @@ static Obj  HdlrFunc27 (
  /* if not IsNoImmediateMethodsObject( obj ) then */
  t_4 = GF_IsNoImmediateMethodsObject;
  t_3 = CALL_1ARGS( t_4, a_obj );
- CHECK_FUNC_RESULT( t_3 );
- CHECK_BOOL( t_3 );
+ CHECK_FUNC_RESULT( t_3 )
+ CHECK_BOOL( t_3 )
  t_2 = (Obj)(UInt)(t_3 != False);
  t_1 = (Obj)(UInt)( ! ((Int)t_2) );
  if ( t_1 ) {
@@ -2358,8 +2358,8 @@ static Obj  HdlrFunc28 (
  /* if not IsType( type ) then */
  t_4 = GF_IsType;
  t_3 = CALL_1ARGS( t_4, a_type );
- CHECK_FUNC_RESULT( t_3 );
- CHECK_BOOL( t_3 );
+ CHECK_FUNC_RESULT( t_3 )
+ CHECK_BOOL( t_3 )
  t_2 = (Obj)(UInt)(t_3 != False);
  t_1 = (Obj)(UInt)( ! ((Int)t_2) );
  if ( t_1 ) {
@@ -2375,8 +2375,8 @@ static Obj  HdlrFunc28 (
  /* if IS_POSOBJ( obj ) then */
  t_3 = GF_IS__POSOBJ;
  t_2 = CALL_1ARGS( t_3, a_obj );
- CHECK_FUNC_RESULT( t_2 );
- CHECK_BOOL( t_2 );
+ CHECK_FUNC_RESULT( t_2 )
+ CHECK_BOOL( t_2 )
  t_1 = (Obj)(UInt)(t_2 != False);
  if ( t_1 ) {
   
@@ -2390,8 +2390,8 @@ static Obj  HdlrFunc28 (
  else {
   t_3 = GF_IS__COMOBJ;
   t_2 = CALL_1ARGS( t_3, a_obj );
-  CHECK_FUNC_RESULT( t_2 );
-  CHECK_BOOL( t_2 );
+  CHECK_FUNC_RESULT( t_2 )
+  CHECK_BOOL( t_2 )
   t_1 = (Obj)(UInt)(t_2 != False);
   if ( t_1 ) {
    
@@ -2405,8 +2405,8 @@ static Obj  HdlrFunc28 (
   else {
    t_3 = GF_IS__DATOBJ;
    t_2 = CALL_1ARGS( t_3, a_obj );
-   CHECK_FUNC_RESULT( t_2 );
-   CHECK_BOOL( t_2 );
+   CHECK_FUNC_RESULT( t_2 )
+   CHECK_BOOL( t_2 )
    t_1 = (Obj)(UInt)(t_2 != False);
    if ( t_1 ) {
     
@@ -2422,8 +2422,8 @@ static Obj  HdlrFunc28 (
  /* if not IsNoImmediateMethodsObject( obj ) then */
  t_4 = GF_IsNoImmediateMethodsObject;
  t_3 = CALL_1ARGS( t_4, a_obj );
- CHECK_FUNC_RESULT( t_3 );
- CHECK_BOOL( t_3 );
+ CHECK_FUNC_RESULT( t_3 )
+ CHECK_BOOL( t_3 )
  t_2 = (Obj)(UInt)(t_3 != False);
  t_1 = (Obj)(UInt)( ! ((Int)t_2) );
  if ( t_1 ) {
@@ -2472,21 +2472,21 @@ static Obj  HdlrFunc29 (
  /* if IS_POSOBJ( obj ) then */
  t_3 = GF_IS__POSOBJ;
  t_2 = CALL_1ARGS( t_3, a_obj );
- CHECK_FUNC_RESULT( t_2 );
- CHECK_BOOL( t_2 );
+ CHECK_FUNC_RESULT( t_2 )
+ CHECK_BOOL( t_2 )
  t_1 = (Obj)(UInt)(t_2 != False);
  if ( t_1 ) {
   
   /* type := TYPE_OBJ( obj ); */
   t_2 = GF_TYPE__OBJ;
   t_1 = CALL_1ARGS( t_2, a_obj );
-  CHECK_FUNC_RESULT( t_1 );
+  CHECK_FUNC_RESULT( t_1 )
   l_type = t_1;
   
   /* newtype := Subtype2( type, filter ); */
   t_2 = GF_Subtype2;
   t_1 = CALL_2ARGS( t_2, l_type, a_filter );
-  CHECK_FUNC_RESULT( t_1 );
+  CHECK_FUNC_RESULT( t_1 )
   l_newtype = t_1;
   
   /* SET_TYPE_POSOBJ( obj, newtype ); */
@@ -2495,15 +2495,15 @@ static Obj  HdlrFunc29 (
   
   /* if not (IGNORE_IMMEDIATE_METHODS or IsNoImmediateMethodsObject( obj )) then */
   t_4 = GC_IGNORE__IMMEDIATE__METHODS;
-  CHECK_BOUND( t_4, "IGNORE_IMMEDIATE_METHODS" );
-  CHECK_BOOL( t_4 );
+  CHECK_BOUND( t_4, "IGNORE_IMMEDIATE_METHODS" )
+  CHECK_BOOL( t_4 )
   t_3 = (Obj)(UInt)(t_4 != False);
   t_2 = t_3;
   if ( ! t_2 ) {
    t_6 = GF_IsNoImmediateMethodsObject;
    t_5 = CALL_1ARGS( t_6, a_obj );
-   CHECK_FUNC_RESULT( t_5 );
-   CHECK_BOOL( t_5 );
+   CHECK_FUNC_RESULT( t_5 )
+   CHECK_BOOL( t_5 )
    t_4 = (Obj)(UInt)(t_5 != False);
    t_2 = t_4;
   }
@@ -2516,7 +2516,7 @@ static Obj  HdlrFunc29 (
    C_ELM_POSOBJ_NLE( t_4, l_newtype, 2 );
    C_ELM_POSOBJ_NLE( t_5, l_type, 2 );
    t_2 = CALL_2ARGS( t_3, t_4, t_5 );
-   CHECK_FUNC_RESULT( t_2 );
+   CHECK_FUNC_RESULT( t_2 )
    CALL_2ARGS( t_1, a_obj, t_2 );
    
   }
@@ -2528,21 +2528,21 @@ static Obj  HdlrFunc29 (
  else {
   t_3 = GF_IS__COMOBJ;
   t_2 = CALL_1ARGS( t_3, a_obj );
-  CHECK_FUNC_RESULT( t_2 );
-  CHECK_BOOL( t_2 );
+  CHECK_FUNC_RESULT( t_2 )
+  CHECK_BOOL( t_2 )
   t_1 = (Obj)(UInt)(t_2 != False);
   if ( t_1 ) {
    
    /* type := TYPE_OBJ( obj ); */
    t_2 = GF_TYPE__OBJ;
    t_1 = CALL_1ARGS( t_2, a_obj );
-   CHECK_FUNC_RESULT( t_1 );
+   CHECK_FUNC_RESULT( t_1 )
    l_type = t_1;
    
    /* newtype := Subtype2( type, filter ); */
    t_2 = GF_Subtype2;
    t_1 = CALL_2ARGS( t_2, l_type, a_filter );
-   CHECK_FUNC_RESULT( t_1 );
+   CHECK_FUNC_RESULT( t_1 )
    l_newtype = t_1;
    
    /* SET_TYPE_COMOBJ( obj, newtype ); */
@@ -2551,15 +2551,15 @@ static Obj  HdlrFunc29 (
    
    /* if not (IGNORE_IMMEDIATE_METHODS or IsNoImmediateMethodsObject( obj )) then */
    t_4 = GC_IGNORE__IMMEDIATE__METHODS;
-   CHECK_BOUND( t_4, "IGNORE_IMMEDIATE_METHODS" );
-   CHECK_BOOL( t_4 );
+   CHECK_BOUND( t_4, "IGNORE_IMMEDIATE_METHODS" )
+   CHECK_BOOL( t_4 )
    t_3 = (Obj)(UInt)(t_4 != False);
    t_2 = t_3;
    if ( ! t_2 ) {
     t_6 = GF_IsNoImmediateMethodsObject;
     t_5 = CALL_1ARGS( t_6, a_obj );
-    CHECK_FUNC_RESULT( t_5 );
-    CHECK_BOOL( t_5 );
+    CHECK_FUNC_RESULT( t_5 )
+    CHECK_BOOL( t_5 )
     t_4 = (Obj)(UInt)(t_5 != False);
     t_2 = t_4;
    }
@@ -2572,7 +2572,7 @@ static Obj  HdlrFunc29 (
     C_ELM_POSOBJ_NLE( t_4, l_newtype, 2 );
     C_ELM_POSOBJ_NLE( t_5, l_type, 2 );
     t_2 = CALL_2ARGS( t_3, t_4, t_5 );
-    CHECK_FUNC_RESULT( t_2 );
+    CHECK_FUNC_RESULT( t_2 )
     CALL_2ARGS( t_1, a_obj, t_2 );
     
    }
@@ -2584,21 +2584,21 @@ static Obj  HdlrFunc29 (
   else {
    t_3 = GF_IS__DATOBJ;
    t_2 = CALL_1ARGS( t_3, a_obj );
-   CHECK_FUNC_RESULT( t_2 );
-   CHECK_BOOL( t_2 );
+   CHECK_FUNC_RESULT( t_2 )
+   CHECK_BOOL( t_2 )
    t_1 = (Obj)(UInt)(t_2 != False);
    if ( t_1 ) {
     
     /* type := TYPE_OBJ( obj ); */
     t_2 = GF_TYPE__OBJ;
     t_1 = CALL_1ARGS( t_2, a_obj );
-    CHECK_FUNC_RESULT( t_1 );
+    CHECK_FUNC_RESULT( t_1 )
     l_type = t_1;
     
     /* newtype := Subtype2( type, filter ); */
     t_2 = GF_Subtype2;
     t_1 = CALL_2ARGS( t_2, l_type, a_filter );
-    CHECK_FUNC_RESULT( t_1 );
+    CHECK_FUNC_RESULT( t_1 )
     l_newtype = t_1;
     
     /* SET_TYPE_DATOBJ( obj, newtype ); */
@@ -2607,15 +2607,15 @@ static Obj  HdlrFunc29 (
     
     /* if not (IGNORE_IMMEDIATE_METHODS or IsNoImmediateMethodsObject( obj )) then */
     t_4 = GC_IGNORE__IMMEDIATE__METHODS;
-    CHECK_BOUND( t_4, "IGNORE_IMMEDIATE_METHODS" );
-    CHECK_BOOL( t_4 );
+    CHECK_BOUND( t_4, "IGNORE_IMMEDIATE_METHODS" )
+    CHECK_BOOL( t_4 )
     t_3 = (Obj)(UInt)(t_4 != False);
     t_2 = t_3;
     if ( ! t_2 ) {
      t_6 = GF_IsNoImmediateMethodsObject;
      t_5 = CALL_1ARGS( t_6, a_obj );
-     CHECK_FUNC_RESULT( t_5 );
-     CHECK_BOOL( t_5 );
+     CHECK_FUNC_RESULT( t_5 )
+     CHECK_BOOL( t_5 )
      t_4 = (Obj)(UInt)(t_5 != False);
      t_2 = t_4;
     }
@@ -2628,7 +2628,7 @@ static Obj  HdlrFunc29 (
      C_ELM_POSOBJ_NLE( t_4, l_newtype, 2 );
      C_ELM_POSOBJ_NLE( t_5, l_type, 2 );
      t_2 = CALL_2ARGS( t_3, t_4, t_5 );
-     CHECK_FUNC_RESULT( t_2 );
+     CHECK_FUNC_RESULT( t_2 )
      CALL_2ARGS( t_1, a_obj, t_2 );
      
     }
@@ -2640,8 +2640,8 @@ static Obj  HdlrFunc29 (
    else {
     t_3 = GF_IS__PLIST__REP;
     t_2 = CALL_1ARGS( t_3, a_obj );
-    CHECK_FUNC_RESULT( t_2 );
-    CHECK_BOOL( t_2 );
+    CHECK_FUNC_RESULT( t_2 )
+    CHECK_BOOL( t_2 )
     t_1 = (Obj)(UInt)(t_2 != False);
     if ( t_1 ) {
      
@@ -2655,8 +2655,8 @@ static Obj  HdlrFunc29 (
     else {
      t_3 = GF_IS__STRING__REP;
      t_2 = CALL_1ARGS( t_3, a_obj );
-     CHECK_FUNC_RESULT( t_2 );
-     CHECK_BOOL( t_2 );
+     CHECK_FUNC_RESULT( t_2 )
+     CHECK_BOOL( t_2 )
      t_1 = (Obj)(UInt)(t_2 != False);
      if ( t_1 ) {
       
@@ -2670,8 +2670,8 @@ static Obj  HdlrFunc29 (
      else {
       t_3 = GF_IS__BLIST;
       t_2 = CALL_1ARGS( t_3, a_obj );
-      CHECK_FUNC_RESULT( t_2 );
-      CHECK_BOOL( t_2 );
+      CHECK_FUNC_RESULT( t_2 )
+      CHECK_BOOL( t_2 )
       t_1 = (Obj)(UInt)(t_2 != False);
       if ( t_1 ) {
        
@@ -2685,8 +2685,8 @@ static Obj  HdlrFunc29 (
       else {
        t_3 = GF_IS__RANGE;
        t_2 = CALL_1ARGS( t_3, a_obj );
-       CHECK_FUNC_RESULT( t_2 );
-       CHECK_BOOL( t_2 );
+       CHECK_FUNC_RESULT( t_2 )
+       CHECK_BOOL( t_2 )
        t_1 = (Obj)(UInt)(t_2 != False);
        if ( t_1 ) {
         
@@ -2746,8 +2746,8 @@ static Obj  HdlrFunc30 (
  /* if IS_AND_FILTER( filter ) then */
  t_3 = GF_IS__AND__FILTER;
  t_2 = CALL_1ARGS( t_3, a_filter );
- CHECK_FUNC_RESULT( t_2 );
- CHECK_BOOL( t_2 );
+ CHECK_FUNC_RESULT( t_2 )
+ CHECK_BOOL( t_2 )
  t_1 = (Obj)(UInt)(t_2 != False);
  if ( t_1 ) {
   
@@ -2762,8 +2762,8 @@ static Obj  HdlrFunc30 (
  /* if IS_POSOBJ( obj ) then */
  t_3 = GF_IS__POSOBJ;
  t_2 = CALL_1ARGS( t_3, a_obj );
- CHECK_FUNC_RESULT( t_2 );
- CHECK_BOOL( t_2 );
+ CHECK_FUNC_RESULT( t_2 )
+ CHECK_BOOL( t_2 )
  t_1 = (Obj)(UInt)(t_2 != False);
  if ( t_1 ) {
   
@@ -2772,9 +2772,9 @@ static Obj  HdlrFunc30 (
   t_3 = GF_SupType2;
   t_5 = GF_TYPE__OBJ;
   t_4 = CALL_1ARGS( t_5, a_obj );
-  CHECK_FUNC_RESULT( t_4 );
+  CHECK_FUNC_RESULT( t_4 )
   t_2 = CALL_2ARGS( t_3, t_4, a_filter );
-  CHECK_FUNC_RESULT( t_2 );
+  CHECK_FUNC_RESULT( t_2 )
   CALL_2ARGS( t_1, a_obj, t_2 );
   
  }
@@ -2783,8 +2783,8 @@ static Obj  HdlrFunc30 (
  else {
   t_3 = GF_IS__COMOBJ;
   t_2 = CALL_1ARGS( t_3, a_obj );
-  CHECK_FUNC_RESULT( t_2 );
-  CHECK_BOOL( t_2 );
+  CHECK_FUNC_RESULT( t_2 )
+  CHECK_BOOL( t_2 )
   t_1 = (Obj)(UInt)(t_2 != False);
   if ( t_1 ) {
    
@@ -2793,9 +2793,9 @@ static Obj  HdlrFunc30 (
    t_3 = GF_SupType2;
    t_5 = GF_TYPE__OBJ;
    t_4 = CALL_1ARGS( t_5, a_obj );
-   CHECK_FUNC_RESULT( t_4 );
+   CHECK_FUNC_RESULT( t_4 )
    t_2 = CALL_2ARGS( t_3, t_4, a_filter );
-   CHECK_FUNC_RESULT( t_2 );
+   CHECK_FUNC_RESULT( t_2 )
    CALL_2ARGS( t_1, a_obj, t_2 );
    
   }
@@ -2804,8 +2804,8 @@ static Obj  HdlrFunc30 (
   else {
    t_3 = GF_IS__DATOBJ;
    t_2 = CALL_1ARGS( t_3, a_obj );
-   CHECK_FUNC_RESULT( t_2 );
-   CHECK_BOOL( t_2 );
+   CHECK_FUNC_RESULT( t_2 )
+   CHECK_BOOL( t_2 )
    t_1 = (Obj)(UInt)(t_2 != False);
    if ( t_1 ) {
     
@@ -2814,9 +2814,9 @@ static Obj  HdlrFunc30 (
     t_3 = GF_SupType2;
     t_5 = GF_TYPE__OBJ;
     t_4 = CALL_1ARGS( t_5, a_obj );
-    CHECK_FUNC_RESULT( t_4 );
+    CHECK_FUNC_RESULT( t_4 )
     t_2 = CALL_2ARGS( t_3, t_4, a_filter );
-    CHECK_FUNC_RESULT( t_2 );
+    CHECK_FUNC_RESULT( t_2 )
     CALL_2ARGS( t_1, a_obj, t_2 );
     
    }
@@ -2825,8 +2825,8 @@ static Obj  HdlrFunc30 (
    else {
     t_3 = GF_IS__PLIST__REP;
     t_2 = CALL_1ARGS( t_3, a_obj );
-    CHECK_FUNC_RESULT( t_2 );
-    CHECK_BOOL( t_2 );
+    CHECK_FUNC_RESULT( t_2 )
+    CHECK_BOOL( t_2 )
     t_1 = (Obj)(UInt)(t_2 != False);
     if ( t_1 ) {
      
@@ -2840,8 +2840,8 @@ static Obj  HdlrFunc30 (
     else {
      t_3 = GF_IS__STRING__REP;
      t_2 = CALL_1ARGS( t_3, a_obj );
-     CHECK_FUNC_RESULT( t_2 );
-     CHECK_BOOL( t_2 );
+     CHECK_FUNC_RESULT( t_2 )
+     CHECK_BOOL( t_2 )
      t_1 = (Obj)(UInt)(t_2 != False);
      if ( t_1 ) {
       
@@ -2855,8 +2855,8 @@ static Obj  HdlrFunc30 (
      else {
       t_3 = GF_IS__BLIST;
       t_2 = CALL_1ARGS( t_3, a_obj );
-      CHECK_FUNC_RESULT( t_2 );
-      CHECK_BOOL( t_2 );
+      CHECK_FUNC_RESULT( t_2 )
+      CHECK_BOOL( t_2 )
       t_1 = (Obj)(UInt)(t_2 != False);
       if ( t_1 ) {
        
@@ -2870,8 +2870,8 @@ static Obj  HdlrFunc30 (
       else {
        t_3 = GF_IS__RANGE;
        t_2 = CALL_1ARGS( t_3, a_obj );
-       CHECK_FUNC_RESULT( t_2 );
-       CHECK_BOOL( t_2 );
+       CHECK_FUNC_RESULT( t_2 )
+       CHECK_BOOL( t_2 )
        t_1 = (Obj)(UInt)(t_2 != False);
        if ( t_1 ) {
         
@@ -2926,7 +2926,7 @@ static Obj  HdlrFunc31 (
  SET_BRK_CURR_STAT(0);
  
  /* if val then */
- CHECK_BOOL( a_val );
+ CHECK_BOOL( a_val )
  t_1 = (Obj)(UInt)(a_val != False);
  if ( t_1 ) {
   
@@ -2991,14 +2991,14 @@ static Obj  HdlrFunc32 (
  SET_BRK_CURR_STAT(0);
  
  /* obj := arg[1]; */
- C_ELM_LIST_FPL( t_1, a_arg, INTOBJ_INT(1) );
+ C_ELM_LIST_FPL( t_1, a_arg, INTOBJ_INT(1) )
  l_obj = t_1;
  
  /* if IsAttributeStoringRep( obj ) then */
  t_3 = GF_IsAttributeStoringRep;
  t_2 = CALL_1ARGS( t_3, l_obj );
- CHECK_FUNC_RESULT( t_2 );
- CHECK_BOOL( t_2 );
+ CHECK_FUNC_RESULT( t_2 )
+ CHECK_BOOL( t_2 )
  t_1 = (Obj)(UInt)(t_2 != False);
  if ( t_1 ) {
   
@@ -3010,25 +3010,25 @@ static Obj  HdlrFunc32 (
   /* type := TypeObj( obj ); */
   t_2 = GF_TypeObj;
   t_1 = CALL_1ARGS( t_2, l_obj );
-  CHECK_FUNC_RESULT( t_1 );
+  CHECK_FUNC_RESULT( t_1 )
   l_type = t_1;
   
   /* flags := FlagsType( type ); */
   t_2 = GF_FlagsType;
   t_1 = CALL_1ARGS( t_2, l_type );
-  CHECK_FUNC_RESULT( t_1 );
+  CHECK_FUNC_RESULT( t_1 )
   l_flags = t_1;
   
   /* nfilt := IS_OBJECT; */
   t_1 = GC_IS__OBJECT;
-  CHECK_BOUND( t_1, "IS_OBJECT" );
+  CHECK_BOUND( t_1, "IS_OBJECT" )
   l_nfilt = t_1;
   
   /* for i in [ 2, 4 .. LEN_LIST( arg ) - 1 ] do */
   t_7 = GF_LEN__LIST;
   t_6 = CALL_1ARGS( t_7, a_arg );
-  CHECK_FUNC_RESULT( t_6 );
-  C_DIFF_FIA( t_5, t_6, INTOBJ_INT(1) );
+  CHECK_FUNC_RESULT( t_6 )
+  C_DIFF_FIA( t_5, t_6, INTOBJ_INT(1) )
   t_4 = Range3Check( INTOBJ_INT(2), INTOBJ_INT(4), t_5 );
   if ( IS_SMALL_LIST(t_4) ) {
    t_3 = (Obj)(UInt)1;
@@ -3052,25 +3052,25 @@ static Obj  HdlrFunc32 (
    l_i = t_2;
    
    /* attr := arg[i]; */
-   CHECK_INT_POS( l_i );
-   C_ELM_LIST_FPL( t_5, a_arg, l_i );
+   CHECK_INT_POS( l_i )
+   C_ELM_LIST_FPL( t_5, a_arg, l_i )
    l_attr = t_5;
    
    /* val := arg[i + 1]; */
-   C_SUM_FIA( t_6, l_i, INTOBJ_INT(1) );
-   CHECK_INT_POS( t_6 );
-   C_ELM_LIST_FPL( t_5, a_arg, t_6 );
+   C_SUM_FIA( t_6, l_i, INTOBJ_INT(1) )
+   CHECK_INT_POS( t_6 )
+   C_ELM_LIST_FPL( t_5, a_arg, t_6 )
    l_val = t_5;
    
    /* if 0 <> FLAG1_FILTER( attr ) then */
    t_7 = GF_FLAG1__FILTER;
    t_6 = CALL_1ARGS( t_7, l_attr );
-   CHECK_FUNC_RESULT( t_6 );
+   CHECK_FUNC_RESULT( t_6 )
    t_5 = (Obj)(UInt)( ! EQ( INTOBJ_INT(0), t_6 ));
    if ( t_5 ) {
     
     /* if val then */
-    CHECK_BOOL( l_val );
+    CHECK_BOOL( l_val )
     t_5 = (Obj)(UInt)(l_val != False);
     if ( t_5 ) {
      
@@ -3079,12 +3079,12 @@ static Obj  HdlrFunc32 (
       t_5 = l_nfilt;
      }
      else if ( l_nfilt == True ) {
-      CHECK_BOOL( l_attr );
+      CHECK_BOOL( l_attr )
       t_5 = l_attr;
      }
      else {
-      CHECK_FUNC( l_nfilt );
-      CHECK_FUNC( l_attr );
+      CHECK_FUNC( l_nfilt )
+      CHECK_FUNC( l_attr )
       t_5 = NewAndFilter( l_nfilt, l_attr );
      }
      l_nfilt = t_5;
@@ -3101,16 +3101,16 @@ static Obj  HdlrFunc32 (
      else if ( l_nfilt == True ) {
       t_7 = GF_Tester;
       t_6 = CALL_1ARGS( t_7, l_attr );
-      CHECK_FUNC_RESULT( t_6 );
-      CHECK_BOOL( t_6 );
+      CHECK_FUNC_RESULT( t_6 )
+      CHECK_BOOL( t_6 )
       t_5 = t_6;
      }
      else {
-      CHECK_FUNC( l_nfilt );
+      CHECK_FUNC( l_nfilt )
       t_8 = GF_Tester;
       t_7 = CALL_1ARGS( t_8, l_attr );
-      CHECK_FUNC_RESULT( t_7 );
-      CHECK_FUNC( t_7 );
+      CHECK_FUNC_RESULT( t_7 )
+      CHECK_FUNC( t_7 )
       t_5 = NewAndFilter( l_nfilt, t_7 );
      }
      l_nfilt = t_5;
@@ -3126,11 +3126,11 @@ static Obj  HdlrFunc32 (
     t_9 = GF_METHODS__OPERATION;
     t_11 = GF_Setter;
     t_10 = CALL_1ARGS( t_11, l_attr );
-    CHECK_FUNC_RESULT( t_10 );
+    CHECK_FUNC_RESULT( t_10 )
     t_8 = CALL_2ARGS( t_9, t_10, INTOBJ_INT(2) );
-    CHECK_FUNC_RESULT( t_8 );
+    CHECK_FUNC_RESULT( t_8 )
     t_6 = CALL_1ARGS( t_7, t_8 );
-    CHECK_FUNC_RESULT( t_6 );
+    CHECK_FUNC_RESULT( t_6 )
     t_5 = (Obj)(UInt)( ! EQ( t_6, INTOBJ_INT(12) ));
     if ( t_5 ) {
      
@@ -3150,10 +3150,10 @@ static Obj  HdlrFunc32 (
      /* obj!.(NAME_FUNC( attr )) := IMMUTABLE_COPY_OBJ( val ); */
      t_6 = GF_NAME__FUNC;
      t_5 = CALL_1ARGS( t_6, l_attr );
-     CHECK_FUNC_RESULT( t_5 );
+     CHECK_FUNC_RESULT( t_5 )
      t_7 = GF_IMMUTABLE__COPY__OBJ;
      t_6 = CALL_1ARGS( t_7, l_val );
-     CHECK_FUNC_RESULT( t_6 );
+     CHECK_FUNC_RESULT( t_6 )
      if ( TNUM_OBJ(l_obj) == T_COMOBJ ) {
       AssPRec( l_obj, RNamObj(t_5), t_6 );
 #ifdef HPCGAP
@@ -3172,16 +3172,16 @@ static Obj  HdlrFunc32 (
      else if ( l_nfilt == True ) {
       t_7 = GF_Tester;
       t_6 = CALL_1ARGS( t_7, l_attr );
-      CHECK_FUNC_RESULT( t_6 );
-      CHECK_BOOL( t_6 );
+      CHECK_FUNC_RESULT( t_6 )
+      CHECK_BOOL( t_6 )
       t_5 = t_6;
      }
      else {
-      CHECK_FUNC( l_nfilt );
+      CHECK_FUNC( l_nfilt )
       t_8 = GF_Tester;
       t_7 = CALL_1ARGS( t_8, l_attr );
-      CHECK_FUNC_RESULT( t_7 );
-      CHECK_FUNC( t_7 );
+      CHECK_FUNC_RESULT( t_7 )
+      CHECK_FUNC( t_7 )
       t_5 = NewAndFilter( l_nfilt, t_7 );
      }
      l_nfilt = t_5;
@@ -3196,14 +3196,14 @@ static Obj  HdlrFunc32 (
   /* nflags := FLAGS_FILTER( nfilt ); */
   t_2 = GF_FLAGS__FILTER;
   t_1 = CALL_1ARGS( t_2, l_nfilt );
-  CHECK_FUNC_RESULT( t_1 );
+  CHECK_FUNC_RESULT( t_1 )
   l_nflags = t_1;
   
   /* if not IS_SUBSET_FLAGS( flags, nflags ) then */
   t_4 = GF_IS__SUBSET__FLAGS;
   t_3 = CALL_2ARGS( t_4, l_flags, l_nflags );
-  CHECK_FUNC_RESULT( t_3 );
-  CHECK_BOOL( t_3 );
+  CHECK_FUNC_RESULT( t_3 )
+  CHECK_BOOL( t_3 )
   t_2 = (Obj)(UInt)(t_3 != False);
   t_1 = (Obj)(UInt)( ! ((Int)t_2) );
   if ( t_1 ) {
@@ -3212,24 +3212,24 @@ static Obj  HdlrFunc32 (
    t_2 = GF_WITH__IMPS__FLAGS;
    t_4 = GF_AND__FLAGS;
    t_3 = CALL_2ARGS( t_4, l_flags, l_nflags );
-   CHECK_FUNC_RESULT( t_3 );
+   CHECK_FUNC_RESULT( t_3 )
    t_1 = CALL_1ARGS( t_2, t_3 );
-   CHECK_FUNC_RESULT( t_1 );
+   CHECK_FUNC_RESULT( t_1 )
    l_flags = t_1;
    
    /* ChangeTypeObj( NEW_TYPE( TypeOfTypes, FamilyType( type ), flags, DataType( type ) ), obj ); */
    t_1 = GF_ChangeTypeObj;
    t_3 = GF_NEW__TYPE;
    t_4 = GC_TypeOfTypes;
-   CHECK_BOUND( t_4, "TypeOfTypes" );
+   CHECK_BOUND( t_4, "TypeOfTypes" )
    t_6 = GF_FamilyType;
    t_5 = CALL_1ARGS( t_6, l_type );
-   CHECK_FUNC_RESULT( t_5 );
+   CHECK_FUNC_RESULT( t_5 )
    t_7 = GF_DataType;
    t_6 = CALL_1ARGS( t_7, l_type );
-   CHECK_FUNC_RESULT( t_6 );
+   CHECK_FUNC_RESULT( t_6 )
    t_2 = CALL_4ARGS( t_3, t_4, t_5, l_flags, t_6 );
-   CHECK_FUNC_RESULT( t_2 );
+   CHECK_FUNC_RESULT( t_2 )
    CALL_2ARGS( t_1, t_2, l_obj );
    
   }
@@ -3238,7 +3238,7 @@ static Obj  HdlrFunc32 (
   /* for i in [ 2, 4 .. LEN_LIST( extra ) ] do */
   t_6 = GF_LEN__LIST;
   t_5 = CALL_1ARGS( t_6, l_extra );
-  CHECK_FUNC_RESULT( t_5 );
+  CHECK_FUNC_RESULT( t_5 )
   t_4 = Range3Check( INTOBJ_INT(2), INTOBJ_INT(4), t_5 );
   if ( IS_SMALL_LIST(t_4) ) {
    t_3 = (Obj)(UInt)1;
@@ -3263,14 +3263,14 @@ static Obj  HdlrFunc32 (
    
    /* Setter( extra[i - 1] )( obj, extra[i] ); */
    t_6 = GF_Setter;
-   C_DIFF_FIA( t_8, l_i, INTOBJ_INT(1) );
-   CHECK_INT_POS( t_8 );
-   C_ELM_LIST_FPL( t_7, l_extra, t_8 );
+   C_DIFF_FIA( t_8, l_i, INTOBJ_INT(1) )
+   CHECK_INT_POS( t_8 )
+   C_ELM_LIST_FPL( t_7, l_extra, t_8 )
    t_5 = CALL_1ARGS( t_6, t_7 );
-   CHECK_FUNC_RESULT( t_5 );
-   CHECK_FUNC( t_5 );
-   CHECK_INT_POS( l_i );
-   C_ELM_LIST_FPL( t_6, l_extra, l_i );
+   CHECK_FUNC_RESULT( t_5 )
+   CHECK_FUNC( t_5 )
+   CHECK_INT_POS( l_i )
+   C_ELM_LIST_FPL( t_6, l_extra, l_i )
    CALL_2ARGS( t_5, l_obj, t_6 );
    
   }
@@ -3287,7 +3287,7 @@ static Obj  HdlrFunc32 (
   /* for i in [ 2, 4 .. LEN_LIST( extra ) ] do */
   t_6 = GF_LEN__LIST;
   t_5 = CALL_1ARGS( t_6, l_extra );
-  CHECK_FUNC_RESULT( t_5 );
+  CHECK_FUNC_RESULT( t_5 )
   t_4 = Range3Check( INTOBJ_INT(2), INTOBJ_INT(4), t_5 );
   if ( IS_SMALL_LIST(t_4) ) {
    t_3 = (Obj)(UInt)1;
@@ -3312,14 +3312,14 @@ static Obj  HdlrFunc32 (
    
    /* Setter( extra[i] )( obj, extra[i + 1] ); */
    t_6 = GF_Setter;
-   CHECK_INT_POS( l_i );
-   C_ELM_LIST_FPL( t_7, l_extra, l_i );
+   CHECK_INT_POS( l_i )
+   C_ELM_LIST_FPL( t_7, l_extra, l_i )
    t_5 = CALL_1ARGS( t_6, t_7 );
-   CHECK_FUNC_RESULT( t_5 );
-   CHECK_FUNC( t_5 );
-   C_SUM_FIA( t_7, l_i, INTOBJ_INT(1) );
-   CHECK_INT_POS( t_7 );
-   C_ELM_LIST_FPL( t_6, l_extra, t_7 );
+   CHECK_FUNC_RESULT( t_5 )
+   CHECK_FUNC( t_5 )
+   C_SUM_FIA( t_7, l_i, INTOBJ_INT(1) )
+   CHECK_INT_POS( t_7 )
+   C_ELM_LIST_FPL( t_6, l_extra, t_7 )
    CALL_2ARGS( t_5, l_obj, t_6 );
    
   }
@@ -3372,17 +3372,17 @@ static Obj  HdlrFunc33 (
  SET_BRK_CURR_STAT(0);
  
  /* obj := arg[1]; */
- C_ELM_LIST_FPL( t_1, a_arg, INTOBJ_INT(1) );
+ C_ELM_LIST_FPL( t_1, a_arg, INTOBJ_INT(1) )
  l_obj = t_1;
  
  /* type := arg[2]; */
- C_ELM_LIST_FPL( t_1, a_arg, INTOBJ_INT(2) );
+ C_ELM_LIST_FPL( t_1, a_arg, INTOBJ_INT(2) )
  l_type = t_1;
  
  /* flags := FlagsType( type ); */
  t_2 = GF_FlagsType;
  t_1 = CALL_1ARGS( t_2, l_type );
- CHECK_FUNC_RESULT( t_1 );
+ CHECK_FUNC_RESULT( t_1 )
  l_flags = t_1;
  
  /* extra := [  ]; */
@@ -3393,10 +3393,10 @@ static Obj  HdlrFunc33 (
  /* if not IS_SUBSET_FLAGS( flags, IsAttributeStoringRepFlags ) then */
  t_4 = GF_IS__SUBSET__FLAGS;
  t_5 = GC_IsAttributeStoringRepFlags;
- CHECK_BOUND( t_5, "IsAttributeStoringRepFlags" );
+ CHECK_BOUND( t_5, "IsAttributeStoringRepFlags" )
  t_3 = CALL_2ARGS( t_4, l_flags, t_5 );
- CHECK_FUNC_RESULT( t_3 );
- CHECK_BOOL( t_3 );
+ CHECK_FUNC_RESULT( t_3 )
+ CHECK_BOOL( t_3 )
  t_2 = (Obj)(UInt)(t_3 != False);
  t_1 = (Obj)(UInt)( ! ((Int)t_2) );
  if ( t_1 ) {
@@ -3404,7 +3404,7 @@ static Obj  HdlrFunc33 (
   /* extra := arg{[ 3 .. LEN_LIST( arg ) ]}; */
   t_4 = GF_LEN__LIST;
   t_3 = CALL_1ARGS( t_4, a_arg );
-  CHECK_FUNC_RESULT( t_3 );
+  CHECK_FUNC_RESULT( t_3 )
   t_2 = Range2Check( INTOBJ_INT(3), t_3 );
   t_1 = ElmsListCheck( a_arg, t_2 );
   l_extra = t_1;
@@ -3426,14 +3426,14 @@ static Obj  HdlrFunc33 (
   
   /* nflags := EMPTY_FLAGS; */
   t_1 = GC_EMPTY__FLAGS;
-  CHECK_BOUND( t_1, "EMPTY_FLAGS" );
+  CHECK_BOUND( t_1, "EMPTY_FLAGS" )
   l_nflags = t_1;
   
   /* for i in [ 3, 5 .. LEN_LIST( arg ) - 1 ] do */
   t_7 = GF_LEN__LIST;
   t_6 = CALL_1ARGS( t_7, a_arg );
-  CHECK_FUNC_RESULT( t_6 );
-  C_DIFF_FIA( t_5, t_6, INTOBJ_INT(1) );
+  CHECK_FUNC_RESULT( t_6 )
+  C_DIFF_FIA( t_5, t_6, INTOBJ_INT(1) )
   t_4 = Range3Check( INTOBJ_INT(3), INTOBJ_INT(5), t_5 );
   if ( IS_SMALL_LIST(t_4) ) {
    t_3 = (Obj)(UInt)1;
@@ -3457,25 +3457,25 @@ static Obj  HdlrFunc33 (
    l_i = t_2;
    
    /* attr := arg[i]; */
-   CHECK_INT_POS( l_i );
-   C_ELM_LIST_FPL( t_5, a_arg, l_i );
+   CHECK_INT_POS( l_i )
+   C_ELM_LIST_FPL( t_5, a_arg, l_i )
    l_attr = t_5;
    
    /* val := arg[i + 1]; */
-   C_SUM_FIA( t_6, l_i, INTOBJ_INT(1) );
-   CHECK_INT_POS( t_6 );
-   C_ELM_LIST_FPL( t_5, a_arg, t_6 );
+   C_SUM_FIA( t_6, l_i, INTOBJ_INT(1) )
+   CHECK_INT_POS( t_6 )
+   C_ELM_LIST_FPL( t_5, a_arg, t_6 )
    l_val = t_5;
    
    /* if 0 <> FLAG1_FILTER( attr ) then */
    t_7 = GF_FLAG1__FILTER;
    t_6 = CALL_1ARGS( t_7, l_attr );
-   CHECK_FUNC_RESULT( t_6 );
+   CHECK_FUNC_RESULT( t_6 )
    t_5 = (Obj)(UInt)( ! EQ( INTOBJ_INT(0), t_6 ));
    if ( t_5 ) {
     
     /* if val then */
-    CHECK_BOOL( l_val );
+    CHECK_BOOL( l_val )
     t_5 = (Obj)(UInt)(l_val != False);
     if ( t_5 ) {
      
@@ -3483,9 +3483,9 @@ static Obj  HdlrFunc33 (
      t_6 = GF_AND__FLAGS;
      t_8 = GF_FLAGS__FILTER;
      t_7 = CALL_1ARGS( t_8, l_attr );
-     CHECK_FUNC_RESULT( t_7 );
+     CHECK_FUNC_RESULT( t_7 )
      t_5 = CALL_2ARGS( t_6, l_nflags, t_7 );
-     CHECK_FUNC_RESULT( t_5 );
+     CHECK_FUNC_RESULT( t_5 )
      l_nflags = t_5;
      
     }
@@ -3498,11 +3498,11 @@ static Obj  HdlrFunc33 (
      t_8 = GF_FLAGS__FILTER;
      t_10 = GF_Tester;
      t_9 = CALL_1ARGS( t_10, l_attr );
-     CHECK_FUNC_RESULT( t_9 );
+     CHECK_FUNC_RESULT( t_9 )
      t_7 = CALL_1ARGS( t_8, t_9 );
-     CHECK_FUNC_RESULT( t_7 );
+     CHECK_FUNC_RESULT( t_7 )
      t_5 = CALL_2ARGS( t_6, l_nflags, t_7 );
-     CHECK_FUNC_RESULT( t_5 );
+     CHECK_FUNC_RESULT( t_5 )
      l_nflags = t_5;
      
     }
@@ -3516,13 +3516,13 @@ static Obj  HdlrFunc33 (
     t_9 = GF_METHODS__OPERATION;
     t_11 = GF_Setter;
     t_10 = CALL_1ARGS( t_11, l_attr );
-    CHECK_FUNC_RESULT( t_10 );
+    CHECK_FUNC_RESULT( t_10 )
     t_8 = CALL_2ARGS( t_9, t_10, INTOBJ_INT(2) );
-    CHECK_FUNC_RESULT( t_8 );
+    CHECK_FUNC_RESULT( t_8 )
     t_6 = CALL_1ARGS( t_7, t_8 );
-    CHECK_FUNC_RESULT( t_6 );
+    CHECK_FUNC_RESULT( t_6 )
     t_7 = GC_LENGTH__SETTER__METHODS__2;
-    CHECK_BOUND( t_7, "LENGTH_SETTER_METHODS_2" );
+    CHECK_BOUND( t_7, "LENGTH_SETTER_METHODS_2" )
     t_5 = (Obj)(UInt)( ! EQ( t_6, t_7 ));
     if ( t_5 ) {
      
@@ -3542,10 +3542,10 @@ static Obj  HdlrFunc33 (
      /* obj.(NAME_FUNC( attr )) := IMMUTABLE_COPY_OBJ( val ); */
      t_6 = GF_NAME__FUNC;
      t_5 = CALL_1ARGS( t_6, l_attr );
-     CHECK_FUNC_RESULT( t_5 );
+     CHECK_FUNC_RESULT( t_5 )
      t_7 = GF_IMMUTABLE__COPY__OBJ;
      t_6 = CALL_1ARGS( t_7, l_val );
-     CHECK_FUNC_RESULT( t_6 );
+     CHECK_FUNC_RESULT( t_6 )
      ASS_REC( l_obj, RNamObj(t_5), t_6 );
      
      /* nflags := AND_FLAGS( nflags, FLAGS_FILTER( Tester( attr ) ) ); */
@@ -3553,11 +3553,11 @@ static Obj  HdlrFunc33 (
      t_8 = GF_FLAGS__FILTER;
      t_10 = GF_Tester;
      t_9 = CALL_1ARGS( t_10, l_attr );
-     CHECK_FUNC_RESULT( t_9 );
+     CHECK_FUNC_RESULT( t_9 )
      t_7 = CALL_1ARGS( t_8, t_9 );
-     CHECK_FUNC_RESULT( t_7 );
+     CHECK_FUNC_RESULT( t_7 )
      t_5 = CALL_2ARGS( t_6, l_nflags, t_7 );
-     CHECK_FUNC_RESULT( t_5 );
+     CHECK_FUNC_RESULT( t_5 )
      l_nflags = t_5;
      
     }
@@ -3570,8 +3570,8 @@ static Obj  HdlrFunc33 (
   /* if not IS_SUBSET_FLAGS( flags, nflags ) then */
   t_4 = GF_IS__SUBSET__FLAGS;
   t_3 = CALL_2ARGS( t_4, l_flags, l_nflags );
-  CHECK_FUNC_RESULT( t_3 );
-  CHECK_BOOL( t_3 );
+  CHECK_FUNC_RESULT( t_3 )
+  CHECK_BOOL( t_3 )
   t_2 = (Obj)(UInt)(t_3 != False);
   t_1 = (Obj)(UInt)( ! ((Int)t_2) );
   if ( t_1 ) {
@@ -3580,24 +3580,24 @@ static Obj  HdlrFunc33 (
    t_2 = GF_WITH__IMPS__FLAGS;
    t_4 = GF_AND__FLAGS;
    t_3 = CALL_2ARGS( t_4, l_flags, l_nflags );
-   CHECK_FUNC_RESULT( t_3 );
+   CHECK_FUNC_RESULT( t_3 )
    t_1 = CALL_1ARGS( t_2, t_3 );
-   CHECK_FUNC_RESULT( t_1 );
+   CHECK_FUNC_RESULT( t_1 )
    l_flags = t_1;
    
    /* Objectify( NEW_TYPE( TypeOfTypes, FamilyType( type ), flags, DataType( type ) ), obj ); */
    t_1 = GF_Objectify;
    t_3 = GF_NEW__TYPE;
    t_4 = GC_TypeOfTypes;
-   CHECK_BOUND( t_4, "TypeOfTypes" );
+   CHECK_BOUND( t_4, "TypeOfTypes" )
    t_6 = GF_FamilyType;
    t_5 = CALL_1ARGS( t_6, l_type );
-   CHECK_FUNC_RESULT( t_5 );
+   CHECK_FUNC_RESULT( t_5 )
    t_7 = GF_DataType;
    t_6 = CALL_1ARGS( t_7, l_type );
-   CHECK_FUNC_RESULT( t_6 );
+   CHECK_FUNC_RESULT( t_6 )
    t_2 = CALL_4ARGS( t_3, t_4, t_5, l_flags, t_6 );
-   CHECK_FUNC_RESULT( t_2 );
+   CHECK_FUNC_RESULT( t_2 )
    CALL_2ARGS( t_1, t_2, l_obj );
    
   }
@@ -3618,8 +3618,8 @@ static Obj  HdlrFunc33 (
  /* for i in [ 1, 3 .. LEN_LIST( extra ) - 1 ] do */
  t_7 = GF_LEN__LIST;
  t_6 = CALL_1ARGS( t_7, l_extra );
- CHECK_FUNC_RESULT( t_6 );
- C_DIFF_FIA( t_5, t_6, INTOBJ_INT(1) );
+ CHECK_FUNC_RESULT( t_6 )
+ C_DIFF_FIA( t_5, t_6, INTOBJ_INT(1) )
  t_4 = Range3Check( INTOBJ_INT(1), INTOBJ_INT(3), t_5 );
  if ( IS_SMALL_LIST(t_4) ) {
   t_3 = (Obj)(UInt)1;
@@ -3644,14 +3644,14 @@ static Obj  HdlrFunc33 (
   
   /* if Tester( extra[i] )( obj ) then */
   t_8 = GF_Tester;
-  CHECK_INT_POS( l_i );
-  C_ELM_LIST_FPL( t_9, l_extra, l_i );
+  CHECK_INT_POS( l_i )
+  C_ELM_LIST_FPL( t_9, l_extra, l_i )
   t_7 = CALL_1ARGS( t_8, t_9 );
-  CHECK_FUNC_RESULT( t_7 );
-  CHECK_FUNC( t_7 );
+  CHECK_FUNC_RESULT( t_7 )
+  CHECK_FUNC( t_7 )
   t_6 = CALL_1ARGS( t_7, l_obj );
-  CHECK_FUNC_RESULT( t_6 );
-  CHECK_BOOL( t_6 );
+  CHECK_FUNC_RESULT( t_6 )
+  CHECK_BOOL( t_6 )
   t_5 = (Obj)(UInt)(t_6 != False);
   if ( t_5 ) {
    
@@ -3659,18 +3659,18 @@ static Obj  HdlrFunc33 (
    t_5 = GF_INFO__OWA;
    C_NEW_STRING( t_6, 32, "#W  Supplied type has tester of " );
    t_8 = GF_NAME__FUNC;
-   C_ELM_LIST_FPL( t_9, l_extra, l_i );
+   C_ELM_LIST_FPL( t_9, l_extra, l_i )
    t_7 = CALL_1ARGS( t_8, t_9 );
-   CHECK_FUNC_RESULT( t_7 );
+   CHECK_FUNC_RESULT( t_7 )
    C_NEW_STRING( t_8, 25, "with non-standard setter\n" );
    CALL_3ARGS( t_5, t_6, t_7, t_8 );
    
    /* ResetFilterObj( obj, Tester( extra[i] ) ); */
    t_5 = GF_ResetFilterObj;
    t_7 = GF_Tester;
-   C_ELM_LIST_FPL( t_8, l_extra, l_i );
+   C_ELM_LIST_FPL( t_8, l_extra, l_i )
    t_6 = CALL_1ARGS( t_7, t_8 );
-   CHECK_FUNC_RESULT( t_6 );
+   CHECK_FUNC_RESULT( t_6 )
    CALL_2ARGS( t_5, l_obj, t_6 );
    
   }
@@ -3678,13 +3678,13 @@ static Obj  HdlrFunc33 (
   
   /* Setter( extra[i] )( obj, extra[i + 1] ); */
   t_6 = GF_Setter;
-  C_ELM_LIST_FPL( t_7, l_extra, l_i );
+  C_ELM_LIST_FPL( t_7, l_extra, l_i )
   t_5 = CALL_1ARGS( t_6, t_7 );
-  CHECK_FUNC_RESULT( t_5 );
-  CHECK_FUNC( t_5 );
-  C_SUM_FIA( t_7, l_i, INTOBJ_INT(1) );
-  CHECK_INT_POS( t_7 );
-  C_ELM_LIST_FPL( t_6, l_extra, t_7 );
+  CHECK_FUNC_RESULT( t_5 )
+  CHECK_FUNC( t_5 )
+  C_SUM_FIA( t_7, l_i, INTOBJ_INT(1) )
+  CHECK_INT_POS( t_7 )
+  C_ELM_LIST_FPL( t_6, l_extra, t_7 )
   CALL_2ARGS( t_5, l_obj, t_6 );
   
  }
@@ -3735,8 +3735,8 @@ static Obj  HdlrFunc1 (
  
  /* LENGTH_SETTER_METHODS_2 := LENGTH_SETTER_METHODS_2 + 6; */
  t_2 = GC_LENGTH__SETTER__METHODS__2;
- CHECK_BOUND( t_2, "LENGTH_SETTER_METHODS_2" );
- C_SUM_FIA( t_1, t_2, INTOBJ_INT(6) );
+ CHECK_BOUND( t_2, "LENGTH_SETTER_METHODS_2" )
+ C_SUM_FIA( t_1, t_2, INTOBJ_INT(6) )
  AssGVar( G_LENGTH__SETTER__METHODS__2, t_1 );
  
  /* InstallAttributeFunction( function ( name, filter, getter, setter, tester, mutflag )
@@ -4203,14 +4203,14 @@ static Obj  HdlrFunc1 (
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 7, "TypeObj" );
  t_3 = GC_TYPE__OBJ;
- CHECK_BOUND( t_3, "TYPE_OBJ" );
+ CHECK_BOUND( t_3, "TYPE_OBJ" )
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* BIND_GLOBAL( "FamilyObj", FAMILY_OBJ ); */
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 9, "FamilyObj" );
  t_3 = GC_FAMILY__OBJ;
- CHECK_BOUND( t_3, "FAMILY_OBJ" );
+ CHECK_BOUND( t_3, "FAMILY_OBJ" )
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* BIND_GLOBAL( "FlagsObj", function ( obj )
@@ -4274,9 +4274,9 @@ static Obj  HdlrFunc1 (
  C_NEW_STRING( t_2, 34, "IsNonAtomicComponentObjectRepFlags" );
  t_4 = GF_FLAGS__FILTER;
  t_5 = GC_IsNonAtomicComponentObjectRep;
- CHECK_BOUND( t_5, "IsNonAtomicComponentObjectRep" );
+ CHECK_BOUND( t_5, "IsNonAtomicComponentObjectRep" )
  t_3 = CALL_1ARGS( t_4, t_5 );
- CHECK_FUNC_RESULT( t_3 );
+ CHECK_FUNC_RESULT( t_3 )
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* BIND_GLOBAL( "IsAtomicPositionalObjectRepFlags", FLAGS_FILTER( IsAtomicPositionalObjectRep ) ); */
@@ -4284,9 +4284,9 @@ static Obj  HdlrFunc1 (
  C_NEW_STRING( t_2, 32, "IsAtomicPositionalObjectRepFlags" );
  t_4 = GF_FLAGS__FILTER;
  t_5 = GC_IsAtomicPositionalObjectRep;
- CHECK_BOUND( t_5, "IsAtomicPositionalObjectRep" );
+ CHECK_BOUND( t_5, "IsAtomicPositionalObjectRep" )
  t_3 = CALL_1ARGS( t_4, t_5 );
- CHECK_FUNC_RESULT( t_3 );
+ CHECK_FUNC_RESULT( t_3 )
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* BIND_GLOBAL( "IsReadOnlyPositionalObjectRepFlags", FLAGS_FILTER( IsReadOnlyPositionalObjectRep ) ); */
@@ -4294,16 +4294,16 @@ static Obj  HdlrFunc1 (
  C_NEW_STRING( t_2, 34, "IsReadOnlyPositionalObjectRepFlags" );
  t_4 = GF_FLAGS__FILTER;
  t_5 = GC_IsReadOnlyPositionalObjectRep;
- CHECK_BOUND( t_5, "IsReadOnlyPositionalObjectRep" );
+ CHECK_BOUND( t_5, "IsReadOnlyPositionalObjectRep" )
  t_3 = CALL_1ARGS( t_4, t_5 );
- CHECK_FUNC_RESULT( t_3 );
+ CHECK_FUNC_RESULT( t_3 )
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* BIND_GLOBAL( "Objectify", SetTypeObj ); */
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 9, "Objectify" );
  t_3 = GC_SetTypeObj;
- CHECK_BOUND( t_3, "SetTypeObj" );
+ CHECK_BOUND( t_3, "SetTypeObj" )
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* BIND_GLOBAL( "ChangeTypeObj", function ( type, obj )
@@ -4338,7 +4338,7 @@ static Obj  HdlrFunc1 (
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 11, "ReObjectify" );
  t_3 = GC_ChangeTypeObj;
- CHECK_BOUND( t_3, "ChangeTypeObj" );
+ CHECK_BOUND( t_3, "ChangeTypeObj" )
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* Unbind( SetFilterObj ); */
@@ -4396,7 +4396,7 @@ static Obj  HdlrFunc1 (
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 14, "SET_FILTER_OBJ" );
  t_3 = GC_SetFilterObj;
- CHECK_BOUND( t_3, "SetFilterObj" );
+ CHECK_BOUND( t_3, "SetFilterObj" )
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* BIND_GLOBAL( "ResetFilterObj", function ( obj, filter )
@@ -4438,7 +4438,7 @@ static Obj  HdlrFunc1 (
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 16, "RESET_FILTER_OBJ" );
  t_3 = GC_ResetFilterObj;
- CHECK_BOUND( t_3, "ResetFilterObj" );
+ CHECK_BOUND( t_3, "ResetFilterObj" )
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* BIND_GLOBAL( "SetFeatureObj", function ( obj, filter, val )
@@ -4519,16 +4519,16 @@ static Obj  HdlrFunc1 (
  C_NEW_STRING( t_2, 26, "IsAttributeStoringRepFlags" );
  t_4 = GF_FLAGS__FILTER;
  t_5 = GC_IsAttributeStoringRep;
- CHECK_BOUND( t_5, "IsAttributeStoringRep" );
+ CHECK_BOUND( t_5, "IsAttributeStoringRep" )
  t_3 = CALL_1ARGS( t_4, t_5 );
- CHECK_FUNC_RESULT( t_3 );
+ CHECK_FUNC_RESULT( t_3 )
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* BIND_GLOBAL( "INFO_OWA", Ignore ); */
  t_1 = GF_BIND__GLOBAL;
  C_NEW_STRING( t_2, 8, "INFO_OWA" );
  t_3 = GC_Ignore;
- CHECK_BOUND( t_3, "Ignore" );
+ CHECK_BOUND( t_3, "Ignore" )
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* MAKE_READ_WRITE_GLOBAL( "INFO_OWA" ); */


### PR DESCRIPTION
Started to work on #55.

This now checks all combinations of GMP (builtin/system) x ABI (32/64) x Build(standard or out-of-tree), except system GMP in 32-bit builds (because "trusty" is missing 32bit GMP, see https://github.com/travis-ci/apt-package-whitelist/pull/4018).

TODOs (for this or rather another PR): 
- add testing builds in HPC-GAP compatibility mode
- add AppVeyor builds